### PR TITLE
Fix number formatting issues in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Not released
+- Fix number formatting issues in Safari [#133](https://github.com/CartoDB/carto-react-template/pull/133/)
+
 ## 1.0.0-beta4 (2020-11-25)
 - Update @carto/react dependency to 1.0.0-beta5
 

--- a/template-sample-app/template.json
+++ b/template-sample-app/template.json
@@ -28,7 +28,8 @@
       "lint-staged": "^10.4.0",
       "prettier": "^2.1.2",
       "react-app-rewired": "^2.1.6",
-      "hygen": "^6.0.4"
+      "hygen": "^6.0.4",
+      "@formatjs/intl-numberformat": "^6.0.0"      
     },
     "scripts": {
       "lint": "eslint './src/**/*.{js,jsx}'",

--- a/template-sample-app/template/package.dev.json
+++ b/template-sample-app/template/package.dev.json
@@ -21,7 +21,8 @@
     "react-map-gl": "^5.2.8",
     "react-redux": "^7.1.3",
     "react-router-dom": "^6.0.0-beta.0",
-    "react-scripts": "3.4.3"
+    "react-scripts": "3.4.3",
+    "@formatjs/intl-numberformat": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/template-sample-app/template/src/utils/formatter.js
+++ b/template-sample-app/template/src/utils/formatter.js
@@ -1,3 +1,11 @@
+import '@formatjs/intl-numberformat/polyfill';
+import '@formatjs/intl-numberformat/locale-data/en';
+
+/* 
+  Note: `notation` & `compactDisplay` properties are not supported yet by Safari. 
+  Those require the use of a polyfill: https://www.npmjs.com/package/@formatjs/intl-numberformat
+*/
+
 export const currencyFormatter = (value) => {
   return {
     prefix: '$',

--- a/template-skeleton/template.json
+++ b/template-skeleton/template.json
@@ -27,7 +27,8 @@
       "lint-staged": "^10.4.0",
       "prettier": "^2.1.2",
       "react-app-rewired": "^2.1.6",
-      "hygen": "^6.0.4"
+      "hygen": "^6.0.4",
+      "@formatjs/intl-numberformat": "^6.0.0"
     },
     "scripts": {
       "lint": "eslint './src/**/*.{js,jsx}'",

--- a/template-skeleton/template/package.dev.json
+++ b/template-skeleton/template/package.dev.json
@@ -20,7 +20,8 @@
     "react-map-gl": "^5.2.8",
     "react-redux": "^7.1.3",
     "react-router-dom": "^6.0.0-beta.0",
-    "react-scripts": "3.4.3"
+    "react-scripts": "3.4.3",
+    "@formatjs/intl-numberformat": "^6.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/template-skeleton/template/src/utils/formatter.js
+++ b/template-skeleton/template/src/utils/formatter.js
@@ -1,3 +1,11 @@
+import '@formatjs/intl-numberformat/polyfill';
+import '@formatjs/intl-numberformat/locale-data/en';
+
+/* 
+  Note: `notation` & `compactDisplay` properties are not supported yet by Safari. 
+  Those require the use of a polyfill: https://www.npmjs.com/package/@formatjs/intl-numberformat
+*/
+
 export const currencyFormatter = (value) => {
   return {
     prefix: '$',


### PR DESCRIPTION
Fixes https://github.com/CartoDB/carto-react-template/issues/132

Some properties like `notation` & `compactDisplay` are not supported yet by Safari. To get a better support, we add this polyfill: https://www.npmjs.com/package/@formatjs/intl-numberformat

