### PR TITLE
 feat: adapt UserDatasets to datasets read-all scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Not released
 - Refactor to use local UserMenuLogin for managing Login button [#144](https://github.com/CartoDB/carto-react-template/pull/144)
+- Add a new forceOAuthLogin option to appSlice, so a fullscreen Login protects the whole app [#146](https://github.com/CartoDB/carto-react-template/pull/146)
 
 ## 1.0.0-beta6 (2020-12-04)
 - Improve layout for mobile (specially for iOS) [#141](https://github.com/CartoDB/carto-react-template/pull/141)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Not released
 - Refactor to use local UserMenuLogin for managing Login button [#144](https://github.com/CartoDB/carto-react-template/pull/144)
 - Add a new forceOAuthLogin option to appSlice, so a fullscreen Login protects the whole app [#146](https://github.com/CartoDB/carto-react-template/pull/146)
+- Refactor to adapt UserDatasets to datasets read-all scope [#147](https://github.com/CartoDB/carto-react-template/pull/147)
+- Fix issue with UserDatasets removal [#147](https://github.com/CartoDB/carto-react-template/pull/147)
 
 ## 1.0.0-beta6 (2020-12-04)
 - Improve layout for mobile (specially for iOS) [#141](https://github.com/CartoDB/carto-react-template/pull/141)

--- a/template-sample-app/template/src/App.js
+++ b/template-sample-app/template/src/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useRoutes } from 'react-router-dom';
 
 import {
@@ -14,6 +15,7 @@ import { cartoThemeOptions } from '@carto/react/ui';
 
 import routes from './routes';
 import { Header } from 'components/common/Header';
+import Login from 'components/views/login/Login';
 
 let theme = createMuiTheme(cartoThemeOptions);
 theme = responsiveFontSizes(theme, {
@@ -40,19 +42,30 @@ theme = responsiveFontSizes(theme, {
 const useStyles = makeStyles(() => ({
   root: {
     flex: 1,
-    overflow: 'hidden',
+    overflow: 'hidden'
   },
 }));
 
 function App() {
-  const classes = useStyles();
+  const classes = useStyles();  
+  const forceLogin = useSelector((state) => state.app.forceOAuthLogin);
+  const user = useSelector((state) => state.oauth.userInfo);
+  
+  const displayLogin = forceLogin && !user;
+
   const routing = useRoutes(routes);
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Grid container direction='column' alignItems='stretch' className={classes.root}>
-        <Header></Header>
-        {routing}
+      <Grid container direction='column' className={classes.root}>
+        {displayLogin ? (
+          <Login />
+        ) : (
+            <>
+              <Header />
+              {routing}
+            </>
+          )}
       </Grid>
     </ThemeProvider>
   );

--- a/template-sample-app/template/src/components/layers/OAuthLayer.js
+++ b/template-sample-app/template/src/components/layers/OAuthLayer.js
@@ -17,10 +17,10 @@ export default function OAuthLayer() {
       autohighlight: true,
       stroked: true,
       filled: true,
-      lineWidthMinPixels: 2,
+      lineWidthMinPixels: 1,
       getFillColor: [238, 77, 90],
-      pointRadiusMinPixels: 2.5,
-      getLineColor: [255, 77, 90],
+      pointRadiusMinPixels: 5,
+      getLineColor: [238, 238, 238],
       getRadius: 30,
       getLineWidth: 1,
       onHover: (info) => {

--- a/template-sample-app/template/src/components/views/datasets/UserDatasets.js
+++ b/template-sample-app/template/src/components/views/datasets/UserDatasets.js
@@ -1,16 +1,13 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import {
-  setOAuthApp,
-  setTokenAndUserInfoAsync,
   selectOAuthCredentials,
   addLayer,
   addSource,
   removeLayer,
   removeSource,
 } from '@carto/react/redux';
-import { useOAuthLogin } from '@carto/react/oauth';
 
 import { makeStyles } from '@material-ui/core/styles';
 import {
@@ -22,7 +19,8 @@ import {
   Typography,
 } from '@material-ui/core';
 import { ChevronRight, HighlightOff } from '@material-ui/icons';
-import { setBottomSheetOpen, setError } from 'config/appSlice';
+
+import { setBottomSheetOpen } from 'config/appSlice';
 
 const useStyles = makeStyles((theme) => ({
   loadingSpinner: {
@@ -34,26 +32,18 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const scopeForDataset = (dataset) => {
-  return `datasets:r:${dataset.table_schema}.${dataset.name}`;
-};
-
 const toTitleCase = (str) => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+
+const OAUTH_LAYER = 'oauthLayer';
+const OAUTH_SOURCE = 'oauthSource';
 
 export default function UserDatasets(props) {
   const dispatch = useDispatch();
   const classes = useStyles();
   
-  const { oauthLayer } = useSelector((state) => state.carto.layers);
   const credentials = useSelector(selectOAuthCredentials);
-  const oauthApp = useSelector((state) => state.oauth.oauthApp);
-  const token = useSelector((state) => state.oauth.token);
-  
-  const [dataset, setDataset] = useState(null);
-  const [newTokenRequest, setNewTokenRequest] = useState(false);
-  const [initialToken, setInitialToken] = useState(null);
+  const { oauthLayer } = useSelector((state) => state.carto.layers);
 
-  // Load dataset & layer to store (so to Map)
   const loadDataset = useCallback(
     (selectedDataset) => {
       const { name: datasetName, table_schema: schema } = selectedDataset;
@@ -61,83 +51,26 @@ export default function UserDatasets(props) {
 
       dispatch(
         addSource({
-          id: 'oauthSource',
+          id: OAUTH_SOURCE,
           data: `SELECT * FROM "${schema}".${datasetName}`,
           credentials: dataSourceCredentials,
         })
       );
 
-      dispatch(addLayer({ id: 'oauthLayer', source: 'oauthSource', name: datasetName }));
+      dispatch(addLayer({ id: OAUTH_LAYER, source: OAUTH_SOURCE, layerAttributes: { name: datasetName } }));
+
+      dispatch(setBottomSheetOpen(false));
     },
     [credentials, dispatch]
   );
 
-  // Remove dataset & layer from store (so from Map)
   const removeDataset = useCallback(() => {
-    dispatch(removeLayer('oauthLayer'));
-    dispatch(removeSource('oauthSource'));
-  }, [dispatch]);
-
-  const oauthUpdatedFor = useCallback(
-    (dataset) => {
-      return oauthApp.scopes.includes(scopeForDataset(dataset));
-    },
-    [oauthApp]
-  );
-
-  const authorizeAndLoadDataset = (selectedDataset) => {
-    if (oauthUpdatedFor(selectedDataset)) {
-      loadDataset(selectedDataset);
-    } else {
-      setDataset(selectedDataset); // start the process..., monitored during useEffects
-      setNewTokenRequest(true);
-      setInitialToken(token);
-    }
-    dispatch(setBottomSheetOpen(false));
-  };
-
-  const onParamsRefreshed = (oauthParams) => {
-    if (oauthParams.error) {
-      dispatch(setError(oauthParams.error));
-    } else {
-      dispatch(setTokenAndUserInfoAsync(oauthParams));
-    }
-  };
-
-  const [handleLogin] = useOAuthLogin(oauthApp, onParamsRefreshed);
+    dispatch(removeLayer(OAUTH_LAYER));
+    dispatch(removeSource(OAUTH_SOURCE));
+  }, [dispatch]);  
 
   // cleanup when leaving
   useEffect(() => removeDataset, [removeDataset]);
-
-  useEffect(() => {
-    if (dataset && newTokenRequest && !oauthUpdatedFor(dataset)) {
-      // step 1: require a new OAuth process, including the scope for the dataset
-      const newScopes = new Set(
-        (oauthApp.scopes ? [...oauthApp.scopes] : []).concat(scopeForDataset(dataset))
-      );
-
-      const newOAuth = { ...oauthApp, scopes: [...newScopes] };
-      dispatch(setOAuthApp(newOAuth));
-    }
-  });
-
-  useEffect(() => {
-    if (dataset && newTokenRequest && oauthUpdatedFor(dataset)) {
-      // step 2: login again, once that the new scopes are ready (including the desired datasets)
-      handleLogin();
-      setNewTokenRequest(false);
-    }
-  }, [dataset, newTokenRequest, oauthUpdatedFor, handleLogin]);
-
-  useEffect(() => {
-    const tokenHasBeenRefreshed = token !== initialToken;
-    if (dataset && oauthUpdatedFor(dataset) && tokenHasBeenRefreshed) {
-      // step 3: load dataset, once there is a new token that includes its access
-      loadDataset(dataset);
-      setDataset(null); // ...and finish the process for this dataset
-      setInitialToken(null);
-    }
-  }, [dataset, oauthUpdatedFor, token, initialToken, loadDataset]);
 
   // Loading...
   if (props.loading) {
@@ -159,7 +92,7 @@ export default function UserDatasets(props) {
     <List component='nav' disablePadding={true}>
       {props.datasets.map((dataset) => {
         const labelId = `checkbox-list-label-${dataset.name}`;
-        const datasetLoaded = oauthLayer && oauthLayer.name === dataset.name;
+        const datasetLoaded = oauthLayer && oauthLayer.layerAttributes.name === dataset.name;
         const secondary = toTitleCase(`${dataset.privacy}`);
 
         return (
@@ -170,7 +103,7 @@ export default function UserDatasets(props) {
             button
             role={undefined}
             onClick={() =>
-              datasetLoaded ? removeDataset() : authorizeAndLoadDataset(dataset)
+              datasetLoaded ? removeDataset() : loadDataset(dataset)
             }
           >
             <ListItemText id={labelId} primary={dataset.name} secondary={secondary} />

--- a/template-sample-app/template/src/components/views/login/Login.js
+++ b/template-sample-app/template/src/components/views/login/Login.js
@@ -1,0 +1,77 @@
+import React from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { Button, Container, Grid, makeStyles, Paper, Typography } from "@material-ui/core";
+import { useOAuthLogin } from "@carto/react/oauth";
+import { setTokenAndUserInfoAsync } from "@carto/react/redux";
+
+import { setError } from "config/appSlice";
+
+const useStyles = makeStyles((theme) => ({
+  containerWrapper: {
+    flex: "1 1 auto",
+    display: "flex",
+  },
+  paperForm: {
+    width: theme.spacing(40),
+    height: theme.spacing(32),
+    padding: theme.spacing(4)
+  }
+}));
+
+export default function Login() {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const oauthApp = useSelector((state) => state.oauth.oauthApp);
+
+  const onParamsRefreshed = (oauthParams) => {
+    if (oauthParams.error) {
+      dispatch(setError(`OAuth error: ${oauthParams.error}`));
+    } else {
+      dispatch(setTokenAndUserInfoAsync(oauthParams));
+    }
+  };
+
+  const [handleLogin] = useOAuthLogin(oauthApp, onParamsRefreshed);
+
+  return (
+    <Container className={classes.containerWrapper}>
+      <Grid
+        container
+        spacing={0}
+        direction="column"
+        alignItems="center"
+        justify="center"
+        style={{ minHeight: "100vh" }}
+      >
+
+        <Grid item xs={12}>
+          <Paper
+            variant="elevation"
+            elevation={4}
+            className={classes.paperForm}
+          >
+            <Grid container
+              spacing={4}
+              direction="column"
+              alignItems="center"
+              justify="center">
+              <Grid item>
+                <img src="/logo-primary.svg" alt="CARTO" />
+              </Grid>
+              <Grid item>
+                <Typography>Your credentials are required to login into <strong>CARTO for React app</strong>
+                </Typography>
+              </Grid>
+              <Grid item>
+                <Button color="inherit" variant="outlined" onClick={handleLogin}>
+                  Login
+                </Button>
+              </Grid>
+            </Grid>
+          </Paper>
+        </Grid>
+
+      </Grid>
+    </Container>
+  );
+}

--- a/template-sample-app/template/src/components/views/stores/StoresDetail.js
+++ b/template-sample-app/template/src/components/views/stores/StoresDetail.js
@@ -72,12 +72,22 @@ export default function StoresDetail() {
       });
 
     // Set selected store on the layer
-    dispatch(updateLayer(LAYER_ID, { selectedStore: id }));
-    
+    dispatch(updateLayer(
+      {
+        id: LAYER_ID,
+        layerAttributes: { selectedStore: id }
+      }
+    ));
+
     dispatch(setBottomSheetOpen(true));
 
     return () => {
-      dispatch(updateLayer(LAYER_ID, { selectedStore: null }));
+      dispatch(updateLayer(
+        {
+          id: LAYER_ID,
+          layerAttributes: { selectedStore: null }
+        }
+      ));
       abortController.abort();
     };
   }, [dispatch, source, id, location.state]);

--- a/template-sample-app/template/src/config/appSlice.js
+++ b/template-sample-app/template/src/config/appSlice.js
@@ -6,6 +6,7 @@ const slice = createSlice({
     error: null,
     isolineResult: null,
     bottomSheetOpen: false,
+    forceOAuthLogin: false
   },
   reducers: {
     setIsolineResult: (state, action) => {

--- a/template-sample-app/template/src/config/initialStateSlice.js
+++ b/template-sample-app/template/src/config/initialStateSlice.js
@@ -24,7 +24,7 @@ export const oauthInitialState = {
     scopes: [
       'user:profile', // to load avatar photo
       'datasets:metadata', // to list all your datasets,
-      'datasets:r:*', // to load any of your datasets as a layer
+      'datasets:r:*', // to read any of your datasets
       'dataservices:geocoding', // to use geocoding through Data Services API
       'dataservices:isolines', // to launch isochrones or isodistances through Data Services API
     ],

--- a/template-sample-app/template/src/config/initialStateSlice.js
+++ b/template-sample-app/template/src/config/initialStateSlice.js
@@ -24,6 +24,7 @@ export const oauthInitialState = {
     scopes: [
       'user:profile', // to load avatar photo
       'datasets:metadata', // to list all your datasets,
+      'datasets:r:*', // to load any of your datasets as a layer
       'dataservices:geocoding', // to use geocoding through Data Services API
       'dataservices:isolines', // to launch isochrones or isodistances through Data Services API
     ],

--- a/template-skeleton/template/src/App.js
+++ b/template-skeleton/template/src/App.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useRoutes } from 'react-router-dom';
 
 import {
@@ -14,6 +15,7 @@ import { cartoThemeOptions } from '@carto/react/ui';
 
 import routes from './routes';
 import { Header } from 'components/common/Header';
+import Login from 'components/views/login/Login';
 
 let theme = createMuiTheme(cartoThemeOptions);
 theme = responsiveFontSizes(theme, {
@@ -40,19 +42,30 @@ theme = responsiveFontSizes(theme, {
 const useStyles = makeStyles(() => ({
   root: {
     flex: 1,
-    overflow: 'hidden'
+    overflow: 'hidden',
   },
 }));
 
 function App() {
   const classes = useStyles();
+  const forceLogin = useSelector((state) => state.app.forceOAuthLogin);
+  const user = useSelector((state) => state.oauth.userInfo);
+
+  const displayLogin = forceLogin && !user;
+
   const routing = useRoutes(routes);
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Grid container direction='column' className={classes.root}>
-        <Header></Header>
-        {routing}
+        {displayLogin ? (
+          <Login />
+        ) : (
+          <>
+            <Header />
+            {routing}
+          </>
+        )}
       </Grid>
     </ThemeProvider>
   );

--- a/template-skeleton/template/src/components/views/login/Login.js
+++ b/template-skeleton/template/src/components/views/login/Login.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  Button,
+  Container,
+  Grid,
+  makeStyles,
+  Paper,
+  Typography,
+} from '@material-ui/core';
+import { useOAuthLogin } from '@carto/react/oauth';
+import { setTokenAndUserInfoAsync } from '@carto/react/redux';
+
+import { setError } from 'config/appSlice';
+
+const useStyles = makeStyles((theme) => ({
+  containerWrapper: {
+    flex: '1 1 auto',
+    display: 'flex',
+  },
+  paperForm: {
+    width: theme.spacing(40),
+    height: theme.spacing(32),
+    padding: theme.spacing(4),
+  },
+}));
+
+export default function Login() {
+  const classes = useStyles();
+  const dispatch = useDispatch();
+  const oauthApp = useSelector((state) => state.oauth.oauthApp);
+
+  const onParamsRefreshed = (oauthParams) => {
+    if (oauthParams.error) {
+      dispatch(setError(`OAuth error: ${oauthParams.error}`));
+    } else {
+      dispatch(setTokenAndUserInfoAsync(oauthParams));
+    }
+  };
+
+  const [handleLogin] = useOAuthLogin(oauthApp, onParamsRefreshed);
+
+  return (
+    <Container className={classes.containerWrapper}>
+      <Grid
+        container
+        spacing={0}
+        direction='column'
+        alignItems='center'
+        justify='center'
+        style={{ minHeight: '100vh' }}
+      >
+        <Grid item xs={12}>
+          <Paper variant='elevation' elevation={4} className={classes.paperForm}>
+            <Grid
+              container
+              spacing={4}
+              direction='column'
+              alignItems='center'
+              justify='center'
+            >
+              <Grid item>
+                <img src='/logo-primary.svg' alt='CARTO' />
+              </Grid>
+              <Grid item>
+                <Typography>
+                  Your credentials are required to login into{' '}
+                  <strong>CARTO for React app</strong>
+                </Typography>
+              </Grid>
+              <Grid item>
+                <Button color='inherit' variant='outlined' onClick={handleLogin}>
+                  Login
+                </Button>
+              </Grid>
+            </Grid>
+          </Paper>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+}

--- a/template-skeleton/template/src/config/appSlice.js
+++ b/template-skeleton/template/src/config/appSlice.js
@@ -5,7 +5,8 @@ const slice = createSlice({
   initialState: {
     error: null,
     isolineResult: null,
-    bottomSheetOpen: false
+    bottomSheetOpen: false,
+    forceOAuthLogin: false,
   },
   reducers: {
     setIsolineResult: (state, action) => {
@@ -16,7 +17,7 @@ const slice = createSlice({
     },
     setBottomSheetOpen: (state, action) => {
       state.bottomSheetOpen = action.payload;
-    }
+    },
   },
 });
 
@@ -24,4 +25,7 @@ export default slice.reducer;
 
 export const setIsolineResult = (payload) => ({ type: 'app/setIsolineResult', payload });
 export const setError = (payload) => ({ type: 'app/setError', payload });
-export const setBottomSheetOpen = (payload) => ({ type: 'app/setBottomSheetOpen', payload });
+export const setBottomSheetOpen = (payload) => ({
+  type: 'app/setBottomSheetOpen',
+  payload,
+});


### PR DESCRIPTION
TO BE MERGED AFTER: #146 

Use again datasets read all scope, with better performance. This is a simplified approach, without requiring an extra OAuth request per each dataset.

It requires first https://github.com/CartoDB/carto-react-lib/pull/45/ to fix an issue with removeLayer (and change of icon in the datasets list)