### PR TITLE
fix: use of layerAttributes in UserDatasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Not released
+- Fix use of layerAttributes in UserDatasets [#154](https://github.com/CartoDB/carto-react-template/pull/154)
+
 ## 1.0.0-beta7 (2020-12-15)
 - Refactor to use local UserMenuLogin for managing Login button [#144](https://github.com/CartoDB/carto-react-template/pull/144)
 - Add a new forceOAuthLogin option to appSlice, so a fullscreen Login protects the whole app [#146](https://github.com/CartoDB/carto-react-template/pull/146)

--- a/template-sample-app/template/src/components/views/datasets/UserDatasets.js
+++ b/template-sample-app/template/src/components/views/datasets/UserDatasets.js
@@ -109,8 +109,7 @@ export default function UserDatasets(props) {
     <List component='nav' disablePadding={true}>
       {props.datasets.map((dataset) => {
         const labelId = `checkbox-list-label-${dataset.name}`;
-        const datasetLoaded =
-          oauthLayer && oauthLayer.layerAttributes.name === dataset.name;
+        const datasetLoaded = oauthLayer && oauthLayer.name === dataset.name;
         const secondary = toTitleCase(`${dataset.privacy}`);
 
         return (


### PR DESCRIPTION
Small change after https://github.com/CartoDB/carto-react-lib/pull/52

The final decision is to be homogeneous on `layerAttributes` param behaviour, for both `addLayer` and `updateLayer` actions, reading the params directly from the layer