### PR TITLE
fix: missing babel dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Not released
+- Fix missing babel dependencies when using CRA for both templates [#160](https://github.com/CartoDB/carto-react-template/issues/160)
+
 ## 1.0.0-beta9 (2020-12-18)
 - Fix use of layerAttributes in UserDatasets [#154](https://github.com/CartoDB/carto-react-template/pull/154)
 - Improve stores layout and loading [#155](https://github.com/CartoDB/carto-react-template/pull/155)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Not released
+## 1.0.0-beta10 (2021-01-16)
 - Fix missing babel dependencies when using CRA for both templates [#160](https://github.com/CartoDB/carto-react-template/issues/160)
 
 ## 1.0.0-beta9 (2020-12-18)

--- a/template-sample-app/package.json
+++ b/template-sample-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-sample-app",
-  "version": "1.0.0-beta9",
+  "version": "1.0.0-beta10",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-sample-app/template.json
+++ b/template-sample-app/template.json
@@ -3,7 +3,7 @@
     "dependencies": {
       "@babel/helper-builder-react-jsx": "^7.10.4",
       "@babel/plugin-transform-react-jsx": "^7.12.12",
-      "@carto/react": "^1.0.0-beta9",
+      "@carto/react": "^1.0.0-beta10",
       "@formatjs/intl-getcanonicallocales": "^1.5.2",
       "@formatjs/intl-locale": "^2.4.8",
       "@formatjs/intl-numberformat": "^6.0.0",

--- a/template-sample-app/template.json
+++ b/template-sample-app/template.json
@@ -1,6 +1,8 @@
 {
   "package": {
     "dependencies": {
+      "@babel/helper-builder-react-jsx": "^7.10.4",
+      "@babel/plugin-transform-react-jsx": "^7.12.12",
       "@carto/react": "^1.0.0-beta9",
       "@formatjs/intl-getcanonicallocales": "^1.5.2",
       "@formatjs/intl-locale": "^2.4.8",

--- a/template-sample-app/template/package.dev.json
+++ b/template-sample-app/template/package.dev.json
@@ -1,9 +1,9 @@
 {
   "name": "react-boilerplate",
-  "version": "1.0.0-beta9",
+  "version": "1.0.0-beta10",
   "private": true,
   "dependencies": {
-    "@carto/react": "^1.0.0-beta9",
+    "@carto/react": "^1.0.0-beta10",
     "@formatjs/intl-getcanonicallocales": "^1.5.2",
     "@formatjs/intl-locale": "^2.4.8",
     "@formatjs/intl-numberformat": "^6.0.0",

--- a/template-skeleton/package.json
+++ b/template-skeleton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template",
-  "version": "1.0.0-beta9",
+  "version": "1.0.0-beta10",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-skeleton/template.json
+++ b/template-skeleton/template.json
@@ -3,7 +3,7 @@
     "dependencies": {
       "@babel/helper-builder-react-jsx": "^7.10.4",
       "@babel/plugin-transform-react-jsx": "^7.12.12",
-      "@carto/react": "^1.0.0-beta9",
+      "@carto/react": "^1.0.0-beta10",
       "@formatjs/intl-getcanonicallocales": "^1.5.2",
       "@formatjs/intl-locale": "^2.4.8",
       "@formatjs/intl-numberformat": "^6.0.0",

--- a/template-skeleton/template.json
+++ b/template-skeleton/template.json
@@ -1,6 +1,8 @@
 {
   "package": {
     "dependencies": {
+      "@babel/helper-builder-react-jsx": "^7.10.4",
+      "@babel/plugin-transform-react-jsx": "^7.12.12",
       "@carto/react": "^1.0.0-beta9",
       "@formatjs/intl-getcanonicallocales": "^1.5.2",
       "@formatjs/intl-locale": "^2.4.8",

--- a/template-skeleton/template/package.dev.json
+++ b/template-skeleton/template/package.dev.json
@@ -1,9 +1,9 @@
 {
   "name": "react-boilerplate",
-  "version": "1.0.0-beta9",
+  "version": "1.0.0-beta10",
   "private": true,
   "dependencies": {
-    "@carto/react": "^1.0.0-beta9",
+    "@carto/react": "^1.0.0-beta10",
     "@formatjs/intl-getcanonicallocales": "^1.5.2",
     "@formatjs/intl-locale": "^2.4.8",
     "@formatjs/intl-numberformat": "^6.0.0",


### PR DESCRIPTION
Related to https://github.com/CartoDB/carto-react-template/issues/160

Some dependencies are not detected using cra by an end user, during yarn start (from node14 LTS). Those are added here to dependencies, as no devDependencies are allowed in the template.json file for a template.

This will be treated as a hot-fix release.