### PR TITLE
fix: basic tab layout id broken on first load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+- Fix basic tab layout id broken on first load [#162](https://github.com/CartoDB/carto-react-template/issues/162)
+
 ## 1.0.0-beta10 (2021-01-16)
 - Fix missing babel dependencies when using CRA for both templates [#160](https://github.com/CartoDB/carto-react-template/issues/160)
 

--- a/template-sample-app/template/src/components/views/Main.js
+++ b/template-sample-app/template/src/components/views/Main.js
@@ -206,7 +206,7 @@ export default function Main() {
         <Portal container={isMobile ? mobileContainer.current : desktopContainer.current}>
           <Outlet />
         </Portal>
-        <Hidden xsDown>
+        <Hidden xsDown implementation='css'>
           <Drawer
             classes={{
               paper: classes.drawerPaper,
@@ -221,7 +221,7 @@ export default function Main() {
             <Grid container item xs ref={desktopContainer}></Grid>
           </Drawer>
         </Hidden>
-        <Hidden smUp>
+        <Hidden smUp implementation='css'>
           <SwipeableDrawer
             variant='persistent'
             anchor='bottom'

--- a/template-skeleton/template/src/components/views/Main.js
+++ b/template-skeleton/template/src/components/views/Main.js
@@ -184,7 +184,7 @@ export default function Main() {
         <Portal container={isMobile ? mobileContainer.current : desktopContainer.current}>
           <Outlet />
         </Portal>
-        <Hidden xsDown>
+        <Hidden xsDown implementation='css'>
           <Drawer
             classes={{
               paper: classes.drawerPaper,
@@ -199,7 +199,7 @@ export default function Main() {
             <Grid container item xs ref={desktopContainer}></Grid>
           </Drawer>
         </Hidden>
-        <Hidden smUp>
+        <Hidden smUp implementation='css'>
           <SwipeableDrawer
             variant='persistent'
             anchor='bottom'
@@ -239,9 +239,11 @@ export default function Main() {
         </Hidden>
         {!isGmaps && <img src={cartoLogo} alt='CARTO' className={classes.cartoLogo} />}
       </Grid>
+
       <Snackbar open={!!error} autoHideDuration={3000} onClose={handleClose}>
         <Alert severity='error'>{error}</Alert>
       </Snackbar>
+
     </Grid>
   );
 }


### PR DESCRIPTION
Due to the lack of a required ref to the dom element

Related to #162 