### PR TITLE
Update deck.gl to 8.4.0-beta.2

### DIFF
--- a/template-sample-app/template.json
+++ b/template-sample-app/template.json
@@ -17,7 +17,7 @@
       "@testing-library/react": "^9.3.2",
       "@testing-library/user-event": "^7.1.2",
       "cypress": "^6.3.0",
-      "deck.gl": "^8.4.0-beta.1",
+      "deck.gl": "^8.4.0-beta.2",
       "echarts": "^4.9.0",
       "echarts-for-react": "^2.0.16",
       "history": "^5.0.0",

--- a/template-sample-app/template/package.dev.json
+++ b/template-sample-app/template/package.dev.json
@@ -17,7 +17,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "cypress": "^6.3.0",
-    "deck.gl": "^8.4.0-beta.1",
+    "deck.gl": "^8.4.0-beta.2",
     "echarts": "^4.9.0",
     "echarts-for-react": "^2.0.16",
     "history": "^5.0.0",

--- a/template-skeleton/template.json
+++ b/template-skeleton/template.json
@@ -17,7 +17,7 @@
       "@testing-library/react": "^9.3.2",
       "@testing-library/user-event": "^7.1.2",
       "cypress": "^6.3.0",
-      "deck.gl": "^8.4.0-beta.1",
+      "deck.gl": "^8.4.0-beta.2",
       "echarts": "^4.9.0",
       "echarts-for-react": "^2.0.16",
       "history": "^5.0.0",

--- a/template-skeleton/template/package.dev.json
+++ b/template-skeleton/template/package.dev.json
@@ -17,7 +17,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "cypress": "^6.3.0",
-    "deck.gl": "^8.4.0-beta.1",
+    "deck.gl": "^8.4.0-beta.2",
     "echarts": "^4.9.0",
     "echarts-for-react": "^2.0.16",
     "history": "^5.0.0",


### PR DESCRIPTION
Update deck.gl version to `8.4.0-beta.2`. `MVTLayer` binary data support included (among other improvements).