### PR TITLE
fix: add required id prop in Formula Widget

### DIFF
--- a/docs/guides/02_page_layer_widgets.md
+++ b/docs/guides/02_page_layer_widgets.md
@@ -221,6 +221,7 @@ Replace the text `Hello World` with:
 ```javascript
 <div>
   <FormulaWidget
+    id='totalRevenue'
     title='Total revenue'
     dataSource={storesSource.id}
     column={STORES_SOURCE_COLUMNS.REVENUE}

--- a/template-sample-app/template/src/components/views/Tileset.js
+++ b/template-sample-app/template/src/components/views/Tileset.js
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { setBottomSheetOpen, setError } from 'config/appSlice';
 
-import { Divider, Typography, makeStyles } from '@material-ui/core';
+import { Divider, Grid, Typography, makeStyles } from '@material-ui/core';
 
 import {
   addLayer,
@@ -14,8 +14,8 @@ import {
 import { AggregationTypes, FormulaWidget, HistogramWidget } from '@carto/react/widgets';
 
 import { numberFormatter } from 'utils/formatter';
-import { TILESET_LAYER_ID } from 'components/layers/TilesetLayer'
-import tilesetSource from 'data/sources/tilesetSource'
+import { TILESET_LAYER_ID } from 'components/layers/TilesetLayer';
+import tilesetSource from 'data/sources/tilesetSource';
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -41,9 +41,7 @@ export default function Tileset() {
       })
     );
 
-    dispatch(
-      addSource(tilesetSource)
-    );
+    dispatch(addSource(tilesetSource));
 
     dispatch(
       addLayer({
@@ -66,7 +64,7 @@ export default function Tileset() {
   };
 
   return (
-    <div>
+    <Grid item xs>
       <Typography variant='h5' gutterBottom className={classes.title}>
         OSM Buildings Analysis
       </Typography>
@@ -98,6 +96,6 @@ export default function Tileset() {
       ></HistogramWidget>
 
       <Divider />
-    </div>
+    </Grid>
   );
 }

--- a/template-sample-app/template/src/components/views/stores/StoresList.js
+++ b/template-sample-app/template/src/components/views/stores/StoresList.js
@@ -8,7 +8,7 @@ import { AggregationTypes } from '@carto/react/widgets';
 import { FormulaWidget, CategoryWidget, HistogramWidget } from '@carto/react/widgets';
 
 import { currencyFormatter, numberFormatter } from 'utils/formatter';
-import storesSource  from 'data/sources/storesSource';
+import storesSource from 'data/sources/storesSource';
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -47,6 +47,7 @@ export default function StoresList() {
       <Divider />
 
       <FormulaWidget
+        id='totalRevenue'
         title='Total revenue'
         dataSource={storesSource.id}
         column='revenue'


### PR DESCRIPTION
#### Background
Related with https://github.com/CartoDB/carto-react-lib/pull/75

#### Change List
- Add required `id` prop for `FormulaWidget`.