### PR TITLE
fix: hard interactivity on mobile - add pickingRadius to layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix error on supportedBrowsers path [#170](https://github.com/CartoDB/carto-react-template/pull/170)
 - Disable immutable & serializable checks for redux store on production [#190](https://github.com/CartoDB/carto-react-template/pull/190)
 - Fix the cleaning of the isochrone if user logouts[#188](https://github.com/CartoDB/carto-react-template/pull/188)
+- Fix hard interactivity on mobile adding pickingRadius to layers [#191](https://github.com/CartoDB/carto-react-template/pull/191)
 
 ## 1.0.0-beta11 (2021-02-02)
 - Remove datasets section [#175](https://github.com/CartoDB/carto-react-template/pull/175)

--- a/template-sample-app/template/src/components/common/Map.js
+++ b/template-sample-app/template/src/components/common/Map.js
@@ -2,7 +2,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import DeckGL from '@deck.gl/react';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { StaticMap } from 'react-map-gl';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, useTheme, useMediaQuery } from '@material-ui/core';
 import { setViewState } from '@carto/react/redux';
 import { BASEMAPS, GoogleMap } from '@carto/react/basemaps';
 
@@ -51,7 +51,9 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function Map({ layers }) {
+  const theme = useTheme();
   const classes = useStyles();
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
   const dispatch = useDispatch();
   const viewState = useSelector((state) => state.carto.viewState);
   const basemap = useSelector((state) => BASEMAPS[state.carto.basemap]);
@@ -96,6 +98,7 @@ function Map({ layers }) {
         onHover={handleHover}
         getCursor={handleCursor}
         getTooltip={handleTooltip}
+        pickingRadius={isMobile ? 10 : 0}
       >
         <StaticMap reuseMaps mapStyle={basemap.options.mapStyle} preventStyleDiffing />
       </DeckGL>

--- a/template-skeleton/template/src/components/common/Map.js
+++ b/template-skeleton/template/src/components/common/Map.js
@@ -2,7 +2,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import DeckGL from '@deck.gl/react';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { StaticMap } from 'react-map-gl';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, useTheme, useMediaQuery } from '@material-ui/core';
 import { setViewState } from '@carto/react/redux';
 import { BASEMAPS, GoogleMap } from '@carto/react/basemaps';
 
@@ -51,7 +51,9 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function Map({ layers }) {
+  const theme = useTheme();
   const classes = useStyles();
+  const isMobile = useMediaQuery(theme.breakpoints.down('xs'));
   const dispatch = useDispatch();
   const viewState = useSelector((state) => state.carto.viewState);
   const basemap = useSelector((state) => BASEMAPS[state.carto.basemap]);
@@ -96,6 +98,7 @@ function Map({ layers }) {
         onHover={handleHover}
         getCursor={handleCursor}
         getTooltip={handleTooltip}
+        pickingRadius={isMobile ? 10 : 0}
       >
         <StaticMap reuseMaps mapStyle={basemap.options.mapStyle} preventStyleDiffing />
       </DeckGL>


### PR DESCRIPTION
There was a hard interaction on mobile when trying to click on layers, especially point type. Added `pickingRadius` to all layers.

For: https://app.clubhouse.io/cartoteam/story/126895/qa-hard-interactivity-on-mobile