### PR TITLE
fix: geocoding marker is not showing on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix error on supportedBrowsers path [#170](https://github.com/CartoDB/carto-react-template/pull/170)
 - Disable immutable & serializable checks for redux store on production [#190](https://github.com/CartoDB/carto-react-template/pull/190)
 - Fix the cleaning of the isochrone if user logouts[#188](https://github.com/CartoDB/carto-react-template/pull/188)
+- Fix geocoding marker is not showing [#192](https://github.com/CartoDB/carto-react-template/pull/192)
 
 ## 1.0.0-beta11 (2021-02-02)
 - Remove datasets section [#175](https://github.com/CartoDB/carto-react-template/pull/175)

--- a/template-sample-app/template/src/components/layers/GeocoderLayer.js
+++ b/template-sample-app/template/src/components/layers/GeocoderLayer.js
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 import { IconLayer } from '@deck.gl/layers';
 import geocoderMarker from 'assets/markers/geocoder-marker.svg';
+import { svgToDataURL } from 'utils/svgToDataUrl';
 
 export const GEOCODER_LAYER_ID = 'geocoderLayer';
 
@@ -14,7 +15,7 @@ function GeocoderLayer() {
     return new IconLayer({
       id: GEOCODER_LAYER_ID,
       getIcon: () => ({
-        url: geocoderMarker,
+        url: svgToDataURL(geocoderMarker),
         width: 56,
         height: 65,
         anchorY: 65,

--- a/template-sample-app/template/src/utils/svgToDataUrl.js
+++ b/template-sample-app/template/src/utils/svgToDataUrl.js
@@ -1,0 +1,3 @@
+export function svgToDataURL(svg) {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+}


### PR DESCRIPTION
Geocoding marker is not showing on Safari.

For: https://app.clubhouse.io/cartoteam/story/132670/qa-safari-geocoding-marker-is-not-showing