### PR TITLE
feat: improve default popup with htmlForFeature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix layer hygen unable to identify proper sources [#198](https://github.com/CartoDB/carto-react-template/pull/198)
 - Fix cross browser geocoder marker display [#199](https://github.com/CartoDB/carto-react-template/pull/199)
 - Change the 'config' folder name to 'store' [#201](https://github.com/CartoDB/carto-react-template/pull/201)
+- Improve default popup with htmlForFeature [#202](https://github.com/CartoDB/carto-react-template/pull/202)
 
 ## 1.0.0-beta12 (2021-02-08)
 - Refactor on basic JSX & JS stuff [#170](https://github.com/CartoDB/carto-react-template/pull/170)

--- a/hygen/_templates/layer/new/layer.ejs.t
+++ b/hygen/_templates/layer/new/layer.ejs.t
@@ -26,7 +26,7 @@ function <%= h.changeCase.pascalCase(name) %>() {
       onHover: (info) => {
         if (info?.object) {
           info.object = {
-            html: htmlForFeature(info.object),
+            html: htmlForFeature({ feature: info.object }),
             style: { }
           };
         }

--- a/template-sample-app/template/src/components/layers/KpiLayer.js
+++ b/template-sample-app/template/src/components/layers/KpiLayer.js
@@ -2,7 +2,7 @@ import { useSelector } from 'react-redux';
 import { CartoSQLLayer, colorBins } from '@deck.gl/carto';
 import { selectSourceById } from '@carto/react/redux';
 import { useCartoLayerFilterProps } from '@carto/react/api';
-import { currencyFormatter } from 'utils/formatter';
+import htmlForFeature from 'utils/htmlForFeature';
 
 export const KPI_LAYER_ID = 'kpiLayer';
 
@@ -45,12 +45,16 @@ function KpiLayer() {
       pickable: true,
       onHover: (info) => {
         if (info?.object) {
-          const formattedRevenue = currencyFormatter(info.object.properties.revenue);
           info.object = {
-            html: `
-              <strong>${info.object.properties.name}</strong><br>
-              ${formattedRevenue.prefix}${formattedRevenue.value}
-            `,
+            html: htmlForFeature({
+              title: `${info.object.properties.name}`,
+              feature: info.object,
+              formatter: {
+                type: 'currency',
+                columns: ['revenue'],
+              },
+              includeColumns: ['revenue'],
+            }),
           };
         }
       },

--- a/template-sample-app/template/src/components/layers/StoresLayer.js
+++ b/template-sample-app/template/src/components/layers/StoresLayer.js
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { CartoSQLLayer, colorCategories } from '@deck.gl/carto';
 import { useCartoLayerFilterProps } from '@carto/react/api';
 import { selectSourceById } from '@carto/react/redux';
-import { currencyFormatter } from 'utils/formatter';
+import htmlForFeature from 'utils/htmlForFeature';
 
 export const STORES_LAYER_ID = 'storesLayer';
 
@@ -47,12 +47,16 @@ function StoresLayer() {
         info.properties.store_id === storesLayer.selectedStore ? 2 : 0,
       onHover: (info) => {
         if (info?.object) {
-          const formattedRevenue = currencyFormatter(info.object.properties.revenue);
           info.object = {
-            html: `
-              <strong>Store ${info.object.properties.store_id}</strong><br>
-              ${formattedRevenue.prefix}${formattedRevenue.value}
-            `,
+            html: htmlForFeature({
+              title: `Store ${info.object.properties.store_id}`,
+              feature: info.object,
+              formatter: {
+                type: 'currency',
+                columns: ['revenue'],
+              },
+              includeColumns: ['revenue'],
+            }),
           };
         }
       },

--- a/template-sample-app/template/src/components/layers/TilesetLayer.js
+++ b/template-sample-app/template/src/components/layers/TilesetLayer.js
@@ -2,6 +2,7 @@ import { useSelector } from 'react-redux';
 import { CartoBQTilerLayer, colorBins } from '@deck.gl/carto';
 import { selectSourceById } from '@carto/react/redux';
 import { useCartoLayerFilterProps } from '@carto/react/api';
+import htmlForFeature from 'utils/htmlForFeature';
 
 export const TILESET_LAYER_ID = 'tilesetLayer';
 
@@ -29,10 +30,15 @@ function TilesetLayer() {
       onHover: (info) => {
         if (info && info.object) {
           info.object = {
-            html: `
-              <strong>Aggregated total</strong><br>
-              ${info.object.properties.aggregated_total}
-            `,
+            html: htmlForFeature({
+              title: 'Aggregated total',
+              feature: info.object,
+              formatter: {
+                type: 'number',
+                columns: ['aggregated_total'],
+              },
+              includeColumns: ['aggregated_total'],
+            }),
           };
         }
       },

--- a/template-sample-app/template/src/utils/htmlForFeature.js
+++ b/template-sample-app/template/src/utils/htmlForFeature.js
@@ -1,10 +1,133 @@
-export default function htmlForFeature(feature) {
+import { currencyFormatter, numberFormatter } from 'utils/formatter';
+
+const FORMATTER_TYPES = Object.freeze({
+  CURRENCY: 'currency',
+  NUMBER: 'number',
+});
+
+const formatterFunctions = {
+  [FORMATTER_TYPES.CURRENCY](value) {
+    const formatted = currencyFormatter(value);
+    return `${formatted.prefix}${formatted.value}`;
+  },
+  [FORMATTER_TYPES.NUMBER](value) {
+    return numberFormatter(value);
+  },
+};
+
+const DEFAULT_FORMATTER = {
+  type: '',
+  columns: [],
+};
+
+export default function htmlForFeature({
+  title,
+  feature,
+  formatter = DEFAULT_FORMATTER,
+  includeColumns = '*',
+  showColumnName = false,
+}) {
+  if (!feature) {
+    throw new Error(`htmlForFeature needs "info.object" information`);
+  }
+
+  const propertyNames = Object.keys(feature.properties);
+
+  if (
+    formatter?.type &&
+    formatter?.columns &&
+    !isFormatterValid(propertyNames, formatter)
+  ) {
+    return;
+  }
+
+  if (!areIncludeColumnsValid(propertyNames, includeColumns)) {
+    return;
+  }
+
   let html = '';
-  Object.keys(feature.properties).forEach((propertyName) => {
-    if (propertyName === 'layerName') return;
-    html = html.concat(
-      `<strong>${propertyName}</strong>: ${feature.properties[propertyName]}<br/>`
-    );
-  });
+
+  if (title) {
+    html = `<h3 style="margin: 0"><strong>${title}</strong></h3>`;
+  }
+
+  for (const name of propertyNames) {
+    if (
+      name !== 'layerName' &&
+      (includeColumns.includes(name) || includeColumns === '*')
+    ) {
+      if (formatter?.columns.includes(name)) {
+        const formatterFunction = formatterFunctions[formatter.type];
+        html = generateHtml(feature, name, showColumnName, html, formatterFunction);
+      } else {
+        html = generateHtml(feature, name, showColumnName, html);
+      }
+    }
+  }
+
   return html;
+}
+
+function generateHtml(
+  feature,
+  propertyName,
+  showColumnName,
+  html,
+  formatterFunction = (v) => v
+) {
+  return html.concat(
+    `${showColumnName ? `<strong>${propertyName}</strong>: ` : ''}${formatterFunction(
+      feature.properties[propertyName]
+    )}<br/>`
+  );
+}
+
+function isFormatterValid(properties, formatter) {
+  const supportedTypes = Object.values(FORMATTER_TYPES);
+
+  if (!supportedTypes.includes(formatter.type)) {
+    throw new Error(
+      `"${formatter.type}" is not supported as formatter, use one of "${supportedTypes}"`
+    );
+  }
+
+  if (!isArrayOfStrings(formatter.columns)) {
+    throw new Error(`"formatter.columns" property needs to be an array of strings`);
+  }
+
+  for (const column of formatter.columns) {
+    if (!properties.includes(column)) {
+      throw new Error(
+        `"formatted.columns" property needs to be an array of existing feature columns`
+      );
+    }
+  }
+
+  return true;
+}
+
+function areIncludeColumnsValid(properties, includeColumns) {
+  if (includeColumns === '*') {
+    return true;
+  }
+
+  if (!isArrayOfStrings(includeColumns)) {
+    throw new Error(
+      `"includeColumns" property needs to be an array of existing feature columns or "*"`
+    );
+  }
+
+  if (isArrayOfStrings(includeColumns)) {
+    for (const column of includeColumns) {
+      if (!properties.includes(column)) {
+        throw new Error('colums set in "includeColumns" should exist in picked feature');
+      }
+    }
+  }
+
+  return true;
+}
+
+function isArrayOfStrings(value) {
+  return Array.isArray(value) && value.length && value.every(String);
 }

--- a/template-sample-app/template/src/utils/htmlForFeature.js
+++ b/template-sample-app/template/src/utils/htmlForFeature.js
@@ -41,7 +41,7 @@ export default function htmlForFeature({
     return;
   }
 
-  if (!areIncludeColumnsValid(propertyNames, includeColumns)) {
+  if (!includedColumnsAreValid(propertyNames, includeColumns)) {
     return;
   }
 
@@ -106,7 +106,7 @@ function isFormatterValid(properties, formatter) {
   return true;
 }
 
-function areIncludeColumnsValid(properties, includeColumns) {
+function includedColumnsAreValid(properties, includeColumns) {
   if (includeColumns === '*') {
     return true;
   }


### PR DESCRIPTION
Improve default popup with `htmlForFeature` fn.

`htmlForFeature` function now accepts the following parameters as the first argument:
```javascript
title: `String` // popup title, by default comes with a `strong` and `h3` html tags
feature: `{}` // needs `info.object` from deck.gk
formatter: {
  type: `'currency'` | `'number'`,
  columns: `[]` // feature columns to apply the formatter type
}
includeColumns: `[String] | '*'` // include in the popup all fields using '*' or some using `['cartodb_id', 'test']`
showColumnName: `boolean` // whether or not to show the column name as a prefix of the row
```
Example:
```javascript
onHover: (info) => {
  if (info?.object) {
    info.object = {
      html: htmlForFeature({
        title: `${info.object.properties.name}`,
        feature: info.object,
        formatter: {
          type: 'currency',
          columns: ['revenue'],
        },
        includeColumns: ['revenue'],
      }),
    };
  }
}
```
For: https://app.clubhouse.io/cartoteam/story/132879/improve-default-popup-with-htmlforfeature