### PR TITLE
refactor: rename bigquery source type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix cross browser geocoder marker display [#199](https://github.com/CartoDB/carto-react-template/pull/199)
 - Change the 'config' folder name to 'store' [#201](https://github.com/CartoDB/carto-react-template/pull/201)
 - Improve default popup with htmlForFeature [#202](https://github.com/CartoDB/carto-react-template/pull/202)
-- Refactor BigQuery source type name [#203](https://github.com/CartoDB/carto-react-template/pull/203)
+- Change BigQuery source type name from 'bq' to 'bigquery' [#203](https://github.com/CartoDB/carto-react-template/pull/203)
 
 ## 1.0.0-beta12 (2021-02-08)
 - Refactor on basic JSX & JS stuff [#170](https://github.com/CartoDB/carto-react-template/pull/170)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix cross browser geocoder marker display [#199](https://github.com/CartoDB/carto-react-template/pull/199)
 - Change the 'config' folder name to 'store' [#201](https://github.com/CartoDB/carto-react-template/pull/201)
 - Improve default popup with htmlForFeature [#202](https://github.com/CartoDB/carto-react-template/pull/202)
+- Refactor BigQuery source type name [#203](https://github.com/CartoDB/carto-react-template/pull/203)
 
 ## 1.0.0-beta12 (2021-02-08)
 - Refactor on basic JSX & JS stuff [#170](https://github.com/CartoDB/carto-react-template/pull/170)

--- a/hygen/_templates/layer/new/prompt.js
+++ b/hygen/_templates/layer/new/prompt.js
@@ -5,7 +5,7 @@ const { promptArgs, readFile, getFiles } = require('../../promptUtils');
 
 const VIEWS_DIR = 'components/views'
 
-const SOURCE_TYPES = ['sql', 'bq'];
+const SOURCE_TYPES = ['sql', 'bigquery'];
 
 const LAYER_TYPES = {
   [SOURCE_TYPES[0]]: 'CartoSQLLayer',
@@ -56,7 +56,7 @@ const prompt = async ({ prompter, args }) => {
 
   // Detect what kind of layer we need (CartoSQLLayer, CartoBQTilerLayer)
   const selectedSourceFileContent = readFile(`src/data/sources/${answers.source_file}.js`);
-  const res = /(?:type: ')(?<type>sql|bq*)(?:')/g.exec(selectedSourceFileContent);
+  const res = /(?:type: ')(?<type>sql|bigquery*)(?:')/g.exec(selectedSourceFileContent);
   answers.type_source = 'sql';
 
   if (res) {

--- a/hygen/_templates/source/new/prompt.js
+++ b/hygen/_templates/source/new/prompt.js
@@ -3,7 +3,7 @@
 //
 const { promptArgs } = require('../../promptUtils');
 
-const SOURCE_TYPES = ['sql', 'bq'];
+const SOURCE_TYPES = ['sql', 'bigquery'];
 
 const LAYER_TYPES = {
   [SOURCE_TYPES[0]]: {

--- a/hygen/_templates/source/new/source.ejs.t
+++ b/hygen/_templates/source/new/source.ejs.t
@@ -5,10 +5,7 @@ const <%= h.changeCase.constantCase(name) %>_ID = '<%= h.changeCase.camelCase(na
 
 const source = {
   id: <%= h.changeCase.constantCase(name) %>_ID,
-  data: `
-    <%- data -%>
-
-  `,
+  data: '<%- data -%>',
   type: '<%- type -%>',
 };
 

--- a/template-sample-app/template/src/components/layers/KpiLayer.js
+++ b/template-sample-app/template/src/components/layers/KpiLayer.js
@@ -54,6 +54,7 @@ function KpiLayer() {
                 columns: ['revenue'],
               },
               includeColumns: ['revenue'],
+              showColumnName: false,
             }),
           };
         }

--- a/template-sample-app/template/src/components/layers/StoresLayer.js
+++ b/template-sample-app/template/src/components/layers/StoresLayer.js
@@ -56,6 +56,7 @@ function StoresLayer() {
                 columns: ['revenue'],
               },
               includeColumns: ['revenue'],
+              showColumnName: false,
             }),
           };
         }

--- a/template-sample-app/template/src/data/sources/tilesetSource.js
+++ b/template-sample-app/template/src/data/sources/tilesetSource.js
@@ -2,7 +2,7 @@ const TILESET_SOURCE_ID = 'tilesetSource';
 
 const source = {
   id: TILESET_SOURCE_ID,
-  type: 'bq',
+  type: 'bigquery',
   data: 'cartobq.maps.osm_buildings',
 };
 

--- a/template-sample-app/template/src/utils/htmlForFeature.js
+++ b/template-sample-app/template/src/utils/htmlForFeature.js
@@ -25,7 +25,7 @@ export default function htmlForFeature({
   feature,
   formatter = DEFAULT_FORMATTER,
   includeColumns = '*',
-  showColumnName = false,
+  showColumnName = true,
 }) {
   if (!feature) {
     throw new Error(`htmlForFeature needs "info.object" information`);


### PR DESCRIPTION
Rename BigQuery source type, from `bq` to `bigquery`

For: https://app.clubhouse.io/cartoteam/story/135148/rename-source-type-in-template

Related with: https://github.com/CartoDB/carto-react-lib/pull/97