### PR TITLE
Create public apps with cloud native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update to latest carto-react (v1.1.0-alpha.3) adapting to new SQL API (executeSQL) [#242](https://github.com/CartoDB/carto-react-template/pull/242)
 - Update to latest deck.gl (8.5.0-alpha.10) [#242](https://github.com/CartoDB/carto-react-template/pull/242)
+- Allow public apps with Cloud Native [#245](https://github.com/CartoDB/carto-react-template/pull/245)
 
 ## (prerelease) 1.1.0-alpha.0 (2021-05-28)
 

--- a/template-skeleton-cn/template/src/App.js
+++ b/template-skeleton-cn/template/src/App.js
@@ -1,5 +1,3 @@
-import { useSelector, useDispatch } from 'react-redux';
-import { useEffect } from 'react';
 import { useRoutes } from 'react-router-dom';
 import {
   createMuiTheme,
@@ -10,12 +8,11 @@ import {
   ThemeProvider,
 } from '@material-ui/core';
 
-import { useAuth0 } from '@auth0/auth0-react';
 import { cartoThemeOptions } from '@carto/react-ui';
-import { setCredentials } from '@carto/react-redux';
 import routes from './routes';
 import Header from 'components/common/Header';
-import Login from 'components/views/login/Login';
+import { initialState } from 'store/initialStateSlice';
+import Auth0 from './Auth0';
 
 let theme = createMuiTheme(cartoThemeOptions);
 theme = responsiveFontSizes(theme, {
@@ -48,35 +45,24 @@ const useStyles = makeStyles(() => ({
 
 function App() {
   const classes = useStyles();
-  const dispatch = useDispatch();
-  const accessToken = useSelector((state) => state.carto.credentials.accessToken);
   const routing = useRoutes(routes);
-  const { isAuthenticated, isLoading, getAccessTokenSilently } = useAuth0();
 
-  useEffect(() => {
-    if (isAuthenticated) {
-      const getAccessToken = async () => {
-        let accessToken = await getAccessTokenSilently();
-        dispatch(setCredentials({ accessToken }));
-      };
-      getAccessToken();
-    }
-  }, [getAccessTokenSilently, isAuthenticated, dispatch]);
+  let children = (
+    <>
+      <Header />
+      {routing}
+    </>
+  );
 
-  const showLoading = isLoading || (isAuthenticated && !accessToken);
+  if (initialState.oauth) {
+    children = Auth0({ children });
+  }
 
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Grid container direction='column' className={classes.root}>
-        {showLoading && <p>Loading</p>}
-        {!showLoading && !isAuthenticated && <Login />}
-        {accessToken && (
-          <>
-            <Header />
-            {routing}
-          </>
-        )}
+        {children}
       </Grid>
     </ThemeProvider>
   );

--- a/template-skeleton-cn/template/src/Auth0.js
+++ b/template-skeleton-cn/template/src/Auth0.js
@@ -1,0 +1,33 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { useEffect } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { setCredentials } from '@carto/react-redux';
+import Login from 'components/views/login/Login';
+
+function Auth0({ children }) {
+  const dispatch = useDispatch();
+  const accessToken = useSelector((state) => state.carto.credentials.accessToken);
+  const { isAuthenticated, isLoading, getAccessTokenSilently } = useAuth0();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      const getAccessToken = async () => {
+        let accessToken = await getAccessTokenSilently();
+        dispatch(setCredentials({ accessToken }));
+      };
+      getAccessToken();
+    }
+  }, [getAccessTokenSilently, isAuthenticated, dispatch]);
+
+  const showLoading = isLoading || (isAuthenticated && !accessToken);
+
+  return (
+    <>
+      {showLoading && <p>Loading</p>}
+      {!showLoading && !isAuthenticated && <Login />}
+      {accessToken && children}
+    </>
+  );
+}
+
+export default Auth0;

--- a/template-skeleton-cn/template/src/index.js
+++ b/template-skeleton-cn/template/src/index.js
@@ -13,33 +13,42 @@ import App from './App';
 import { Auth0Provider } from '@auth0/auth0-react';
 import { initialState } from 'store/initialStateSlice';
 import configureAppStore from './store/store';
-
 import { createCartoSlice } from '@carto/react-redux';
+import { setDefaultCredentials } from '@deck.gl/carto';
 
 const store = configureAppStore();
 
 store.reducerManager.add('carto', createCartoSlice(initialState));
 
-const { domain, clientId, scopes, audience } = initialState.oauth;
+setDefaultCredentials({ ...initialState.credentials });
 
-if (!clientId) {
-  alert('Need to define a clientId. Please check the file store/initalStateSlice.js');
+let AppProvider = (
+  <Provider store={store}>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </Provider>
+);
+
+if (initialState.oauth) {
+  const { domain, clientId, scopes, audience } = initialState.oauth;
+
+  if (!clientId) {
+    alert('Need to define a clientId. Please check the file store/initalStateSlice.js');
+  }
+
+  AppProvider = (
+    <Auth0Provider
+      domain={domain}
+      clientId={clientId}
+      redirectUri={window.location.origin}
+      scopes={scopes.join(' ')}
+      audience={audience}
+      cacheLocation='localstorage'
+    >
+      {AppProvider}
+    </Auth0Provider>
+  );
 }
 
-ReactDOM.render(
-  <Auth0Provider
-    domain={domain}
-    clientId={clientId}
-    redirectUri={window.location.origin}
-    scopes={scopes.join(' ')}
-    audience={audience}
-    cacheLocation='localstorage'
-  >
-    <Provider store={store}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </Provider>
-  </Auth0Provider>,
-  document.getElementById('root')
-);
+ReactDOM.render(AppProvider, document.getElementById('root'));

--- a/template-skeleton-cn/template/src/routes.js
+++ b/template-skeleton-cn/template/src/routes.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { OAuthCallback } from '@carto/react-auth';
 import Main from 'components/views/Main';
 import NotFound from 'components/views/NotFound';
 // [hygen] Import views
@@ -14,7 +13,6 @@ const routes = [
       // [hygen] Add routes
     ],
   },
-  { path: '/oauthCallback', element: <OAuthCallback /> },
   { path: '404', element: <NotFound /> },
   { path: '*', element: <Navigate to='/404' /> },
 ];


### PR DESCRIPTION
It allows to create public apps with cloud native.

If the `oauth`is missing in the initialSlice the app is public and no login form will appear.

How it works:

1. Create a public token from the tokens api
2. Remove the oauth property from initialSlice.
3. Add the token at initialSlice.

```javascript
import { VOYAGER } from '@carto/react-basemaps';
import { API_VERSIONS } from '@deck.gl/carto';

export const initialState = {
  ...
  credentials: {
    apiVersion: API_VERSIONS.V3,
    apiBaseUrl: 'https://gcp-us-east1.api.carto.com',
    accessToken:
      'XXX',
  },
};
```



![image](https://user-images.githubusercontent.com/1161870/122271080-4d9b8a00-cedf-11eb-8c2e-e928fcc66998.png)


