### PR TITLE
Add a ScatterplotWidget example to sample-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update to latest carto-react (v1.1.0-alpha.3) adapting to new SQL API (executeSQL) [#242](https://github.com/CartoDB/carto-react-template/pull/242)
 - Update to latest deck.gl (8.5.0-alpha.10) [#242](https://github.com/CartoDB/carto-react-template/pull/242)
 - Allow public apps with Cloud Native [#245](https://github.com/CartoDB/carto-react-template/pull/245)
+- Add a ScatterplotWidget example to sample-app [#246](https://github.com/CartoDB/carto-react-template/pull/246)
 
 ## (prerelease) 1.1.0-alpha.0 (2021-05-28)
 

--- a/template-sample-app/template/src/components/views/stores/StoresList.js
+++ b/template-sample-app/template/src/components/views/stores/StoresList.js
@@ -93,7 +93,7 @@ function StoresList() {
 
       <ScatterPlotWidget
         id='revenueBySize'
-        title='Revenue ($) by size (m2)'
+        title='Revenue by size (m2 >> $)'
         dataSource={storesSource.id}
         xAxisColumn='size_m2'
         yAxisColumn='revenue'

--- a/template-sample-app/template/src/components/views/stores/StoresList.js
+++ b/template-sample-app/template/src/components/views/stores/StoresList.js
@@ -3,7 +3,12 @@ import { useDispatch } from 'react-redux';
 import { setBottomSheetOpen, setError } from 'store/appSlice';
 import { Divider, Grid, Typography, makeStyles } from '@material-ui/core';
 import { AggregationTypes } from '@carto/react-core';
-import { FormulaWidget, CategoryWidget, HistogramWidget } from '@carto/react-widgets';
+import {
+  FormulaWidget,
+  CategoryWidget,
+  HistogramWidget,
+  ScatterPlotWidget,
+} from '@carto/react-widgets';
 import { currencyFormatter, numberFormatter } from 'utils/formatter';
 import storesSource from 'data/sources/storesSource';
 
@@ -33,6 +38,10 @@ function StoresList() {
 
   const onStoresByRevenueWidgetError = (error) => {
     dispatch(setError(`Error obtaining stores per revenue: ${error.message}`));
+  };
+
+  const onRevenueBySizeWidgetError = (error) => {
+    dispatch(setError(`Error obtaining revenue per size: ${error.message}`));
   };
 
   return (
@@ -80,6 +89,18 @@ function StoresList() {
         onError={onStoresByRevenueWidgetError}
       />
 
+      <Divider />
+
+      <ScatterPlotWidget
+        id='revenueBySize'
+        title='Revenue ($) by size (m2)'
+        dataSource={storesSource.id}
+        xAxisColumn='size_m2'
+        yAxisColumn='revenue'
+        yAxisFormatter={currencyFormatter}
+        tooltipFormatter={(v) => `${v.value[0]} m2 >> ${v.value[1]} $`}
+        onError={onRevenueBySizeWidgetError}
+      />
       <Divider />
     </Grid>
   );

--- a/template-sample-app/template/src/data/sources/storesSource.js
+++ b/template-sample-app/template/src/data/sources/storesSource.js
@@ -11,6 +11,7 @@ const source = {
       zip,
       storetype,
       revenue,
+      size_m2,
       state,
       the_geom_webmercator
     FROM retail_stores


### PR DESCRIPTION
Thanks to the new widget, available at carto-react lib from 1.1.0-alpha.3

![image](https://user-images.githubusercontent.com/458196/122413072-627f2880-cf86-11eb-8d87-831fded63257.png)