### PR TITLE
Improve default classes name

### DIFF
--- a/template-skeleton/template/src/App.js
+++ b/template-skeleton/template/src/App.js
@@ -36,8 +36,8 @@ theme = responsiveFontSizes(theme, {
 });
 
 const useStyles = makeStyles(() => ({
-  root: {
-    flex: 1,
+  app: {
+    flex: '1 1 auto',
     overflow: 'hidden',
   },
 }));
@@ -53,7 +53,7 @@ export default function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Grid container direction='column' className={classes.root}>
+      <Grid container direction='column' className={classes.app}>
         {displayLogin ? (
           <Login />
         ) : (

--- a/template-skeleton/template/src/components/common/Header.js
+++ b/template-skeleton/template/src/components/common/Header.js
@@ -21,7 +21,7 @@ import cartoLogo from 'assets/img/carto-logo.svg';
 import cartoLogoXs from 'assets/img/carto-logo-xs.svg';
 
 const useStyles = makeStyles((theme) => ({
-  navBar: {
+  header: {
     boxShadow: 'none',
     zIndex: theme.zIndex.modal + 1,
     overflow: 'hidden',
@@ -96,7 +96,7 @@ export default function Header() {
   };
 
   return (
-    <AppBar position='static' className={classes.navBar}>
+    <AppBar position='static' className={classes.header}>
       <Toolbar variant='dense'>
         <Hidden smUp>
           <IconButton

--- a/template-skeleton/template/src/components/common/Map.js
+++ b/template-skeleton/template/src/components/common/Map.js
@@ -7,7 +7,7 @@ import { setViewState } from '@carto/react-redux';
 import { BASEMAPS, GoogleMap } from '@carto/react-basemaps';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
+  map: {
     backgroundColor: theme.palette.grey[50],
     position: 'relative',
     height: `calc(100% - ${theme.spacing(2)}px)`,
@@ -118,5 +118,5 @@ export default function Map({ layers }) {
     );
   }
 
-  return <div className={classes.root}>{map}</div>;
+  return <div className={classes.map}>{map}</div>;
 }

--- a/template-skeleton/template/src/components/common/ZoomControl.js
+++ b/template-skeleton/template/src/components/common/ZoomControl.js
@@ -6,7 +6,7 @@ import RemoveOutlinedIcon from '@material-ui/icons/RemoveOutlined';
 import { setViewState } from '@carto/react-redux';
 
 const useStyles = makeStyles((theme) => ({
-  root: {
+  zoomControl: {
     '& .MuiButton-contained': {
       maxWidth: theme.spacing(4.5),
       minWidth: 'auto',
@@ -40,7 +40,7 @@ function ZoomControl({ className }) {
       variant='contained'
       color='inherit'
       disableRipple={true}
-      className={`${className} ${classes.root}`}
+      className={`${className} ${classes.zoomControl}`}
     >
       <Button onClick={decreaseZoom} aria-label='Decrease zoom'>
         <RemoveOutlinedIcon />

--- a/template-skeleton/template/src/components/views/NotFound.js
+++ b/template-skeleton/template/src/components/views/NotFound.js
@@ -4,7 +4,7 @@ import { NavLink } from 'react-router-dom';
 import background404 from 'assets/img/404.svg';
 
 const useStyles = makeStyles(() => ({
-  containerWrapper: {
+  notFound: {
     flex: '1 1 auto',
     display: 'flex',
   },
@@ -24,7 +24,7 @@ export default function NotFound() {
   const classes = useStyles();
 
   return (
-    <Container className={classes.containerWrapper}>
+    <Container className={classes.notFound}>
       <Grid
         container
         direction='column'

--- a/template-skeleton/template/src/components/views/login/Login.js
+++ b/template-skeleton/template/src/components/views/login/Login.js
@@ -16,7 +16,7 @@ import { setError } from 'store/appSlice';
 import cartoLogoNegative from 'assets/img/carto-logo-negative.svg';
 
 const useStyles = makeStyles((theme) => ({
-  fullContainer: {
+  login: {
     backgroundColor: theme.palette.primary.main,
     height: '100%',
     [theme.breakpoints.up('md')]: {
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
     maxWidth: 485,
     color: theme.palette.common.white,
   },
-  login: {
+  buttonContainer: {
     marginTop: theme.spacing(9),
   },
   contact: {
@@ -91,7 +91,7 @@ export default function Login() {
   return (
     <Grid
       container
-      className={classes.fullContainer}
+      className={classes.login}
       direction='column'
       justify='flex-start'
       alignItems='flex-start'
@@ -119,7 +119,7 @@ export default function Login() {
           </Typography>
         </Grid>
 
-        <Grid item className={classes.login}>
+        <Grid item className={classes.buttonContainer}>
           <Button
             variant='contained'
             color='secondary'


### PR DESCRIPTION
This PR improve the default classes name of component, The main objetive is to facilitate the debugging of the layout and to be able to see better where each component is in the DOM tree.

Before:
![Screenshot 2021-06-17 at 16 42 03](https://user-images.githubusercontent.com/11427698/122420919-4ed6c080-cf8c-11eb-9089-219626fbc26c.png)

After:
![Screenshot 2021-06-17 at 16 46 30](https://user-images.githubusercontent.com/11427698/122420948-54340b00-cf8c-11eb-9489-6bbf6004c6f7.png)

You can see now the makeStyles-<COMPONENT_NAME> instead of makeStyles-root.