### PR TITLE
Update the tileset source to point to carto-demo-data BQ project

### DIFF
--- a/template-sample-app-2/template/src/data/sources/tilesetSource.js
+++ b/template-sample-app-2/template/src/data/sources/tilesetSource.js
@@ -5,7 +5,7 @@ const TILESET_SOURCE_ID = 'tilesetSource';
 const source = {
   id: TILESET_SOURCE_ID,
   type: MAP_TYPES.TILESET,
-  data: 'cartobq.maps.osm_buildings',
+  data: 'carto-demo-data.demo_tilesets.osm_buildings',
 };
 
 export default source;


### PR DESCRIPTION
Update the source used in the Tileset view to point to the same tileset in the carto-demo-data.demo_tilesets dataset.