### PR TITLE
Material-UI error in sample-app-2 template

### DIFF
--- a/template-base-2/template.json
+++ b/template-base-2/template.json
@@ -16,7 +16,7 @@
       "@formatjs/intl-pluralrules": "^4.0.6",
       "@material-ui/core": "^4.11.3",
       "@material-ui/icons": "^4.11.2",
-      "@material-ui/lab": "4.0.0-alpha.57",
+      "@material-ui/lab": "4.0.0-alpha.60",
       "@reduxjs/toolkit": "^1.5.0",
       "@testing-library/jest-dom": "^5.11.9",
       "@testing-library/react": "^11.2.3",

--- a/template-base-2/template/package.dev.json
+++ b/template-base-2/template/package.dev.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-pluralrules": "^4.0.6",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "4.0.0-alpha.57",
+    "@material-ui/lab": "4.0.0-alpha.60",
     "@reduxjs/toolkit": "^1.5.0",
     "@testing-library/cypress": "^7.0.3",
     "@testing-library/jest-dom": "^5.11.9",

--- a/template-base-3/template.json
+++ b/template-base-3/template.json
@@ -16,7 +16,7 @@
       "@formatjs/intl-pluralrules": "^4.0.6",
       "@material-ui/core": "^4.11.3",
       "@material-ui/icons": "^4.11.2",
-      "@material-ui/lab": "4.0.0-alpha.57",
+      "@material-ui/lab": "4.0.0-alpha.60",
       "@reduxjs/toolkit": "^1.5.0",
       "@testing-library/jest-dom": "^5.11.9",
       "@testing-library/react": "^11.2.3",

--- a/template-base-3/template/package.dev.json
+++ b/template-base-3/template/package.dev.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-pluralrules": "^4.0.6",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "4.0.0-alpha.57",
+    "@material-ui/lab": "4.0.0-alpha.60",
     "@reduxjs/toolkit": "^1.5.0",
     "@testing-library/cypress": "^7.0.3",
     "@testing-library/jest-dom": "^5.11.9",

--- a/template-sample-app-2/template.json
+++ b/template-sample-app-2/template.json
@@ -16,7 +16,7 @@
       "@formatjs/intl-pluralrules": "^4.0.6",
       "@material-ui/core": "^4.11.3",
       "@material-ui/icons": "^4.11.2",
-      "@material-ui/lab": "4.0.0-alpha.57",
+      "@material-ui/lab": "4.0.0-alpha.60",
       "@reduxjs/toolkit": "^1.5.0",
       "@testing-library/jest-dom": "^5.11.9",
       "@testing-library/react": "^11.2.3",

--- a/template-sample-app-2/template/package.dev.json
+++ b/template-sample-app-2/template/package.dev.json
@@ -18,7 +18,7 @@
     "@formatjs/intl-pluralrules": "^4.0.6",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
-    "@material-ui/lab": "4.0.0-alpha.57",
+    "@material-ui/lab": "4.0.0-alpha.60",
     "@reduxjs/toolkit": "^1.5.0",
     "@testing-library/cypress": "^7.0.3",
     "@testing-library/jest-dom": "^5.11.9",


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/178038

Updating @material-ui/lab to alpha.60 solves the error.