### PR TITLE
Use of deprecated getRadius in sample-app-2 template

### DIFF
--- a/template-sample-app-2/template/src/components/layers/StoresLayer.js
+++ b/template-sample-app-2/template/src/components/layers/StoresLayer.js
@@ -58,7 +58,7 @@ function StoresLayer() {
         othersColor: OTHERS_COLOR.Others,
       }),
       getLineColor: [0, 0, 0],
-      getRadius: (info) =>
+      getPointRadius: (info) =>
         info.properties.store_id === storesLayer.selectedStore ? 6 : 3,
       getLineWidth: (info) =>
         info.properties.store_id === storesLayer.selectedStore ? 2 : 0,
@@ -92,7 +92,7 @@ function StoresLayer() {
         }
       },
       updateTriggers: {
-        getRadius: { selectedStore: storesLayer.selectedStore },
+        getPointRadius: { selectedStore: storesLayer.selectedStore },
         getLineWidth: { selectedStore: storesLayer.selectedStore },
         ...cartoLayerProps.updateTriggers,
       },


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/178011