### PR TITLE
Wrong query when literal strings are used

### DIFF
--- a/hygen/_templates/source/new/source.ejs.t
+++ b/hygen/_templates/source/new/source.ejs.t
@@ -11,7 +11,7 @@ const source = {
 <% if (platform === 'carto-cloud-native') { -%>
   connection: '<%- connection %>',
 <% } -%>
-  data: '<%- data -%>',
+  data: `<%- data -%>`,
 };
 
 export default source;


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/178973