### PR TITLE
Fix config-overrides.js being ignored in base-3-typescript & sample-app-3

### DIFF
--- a/template-base-3-typescript/template/gitignore
+++ b/template-base-3-typescript/template/gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 package.dev.json
-config-overrides.js
 storybook-static
 .eslintcache
 

--- a/template-sample-app-3/template/gitignore
+++ b/template-sample-app-3/template/gitignore
@@ -1,7 +1,6 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 package.dev.json
-config-overrides.js
 storybook-static
 .eslintcache
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/cartoteam/story/188818