### PR TITLE
Fix useMapHooks to ignore undefined tooltips.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Fix useMapHooks to ignore undefined tooltips [326](https://github.com/CartoDB/carto-react-template/pull/326)
+
 ## 1.2.0
 
 ### (prerelease) 1.2.0-beta.2 (2022-02-16)

--- a/template-base-2/template/src/components/common/map/useMapHooks.js
+++ b/template-base-2/template/src/components/common/map/useMapHooks.js
@@ -48,7 +48,7 @@ export function useMapHooks() {
     isDragging ? 'grabbing' : isHovering ? 'pointer' : 'grab';
 
   const handleTooltip = (info) => {
-    if (info?.object) {
+    if (info?.object?.html) {
       return {
         html: `<div class='content'>${info.object.html}<div class='arrow'></div></div>`,
         className: classes.tooltip,

--- a/template-base-3/template/src/components/common/map/useMapHooks.js
+++ b/template-base-3/template/src/components/common/map/useMapHooks.js
@@ -48,7 +48,7 @@ export function useMapHooks() {
     isDragging ? 'grabbing' : isHovering ? 'pointer' : 'grab';
 
   const handleTooltip = (info) => {
-    if (info?.object) {
+    if (info?.object?.html) {
       return {
         html: `<div class='content'>${info.object.html}<div class='arrow'></div></div>`,
         className: classes.tooltip,

--- a/template-sample-app-2/template/src/components/common/map/useMapHooks.js
+++ b/template-sample-app-2/template/src/components/common/map/useMapHooks.js
@@ -48,7 +48,7 @@ export function useMapHooks() {
     isDragging ? 'grabbing' : isHovering ? 'pointer' : 'grab';
 
   const handleTooltip = (info) => {
-    if (info?.object) {
+    if (info?.object?.html) {
       return {
         html: `<div class='content'>${info.object.html}<div class='arrow'></div></div>`,
         className: classes.tooltip,


### PR DESCRIPTION
Story details:  https://app.shortcut.com/cartoteam/story/211280/template-base-2-feature-selection-widget-with-undefined-label