### PR TITLE
Fix x axis labels of Histogram widget in template-base-{2,3}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Not released
 
+- Fix x axis labels of Histogram widget in template-base-{2,3} [#327](https://github.com/CartoDB/carto-react-template/pull/327)
 - Fix widgets in Tileset view for template-sample-app-3 [#325](https://github.com/CartoDB/carto-react-template/pull/325)
-- Fix useMapHooks to ignore undefined tooltips [326](https://github.com/CartoDB/carto-react-template/pull/326)
+- Fix useMapHooks to ignore undefined tooltips [#326](https://github.com/CartoDB/carto-react-template/pull/326)
+
 ## 1.2.0
 
 ### (prerelease) 1.2.0-beta.2 (2022-02-16)

--- a/template-base-2/template/src/utils/formatter.js
+++ b/template-base-2/template/src/utils/formatter.js
@@ -62,8 +62,8 @@ const parseLogicalOperation = (value) => {
 
     let operation;
     if (match) {
-      operation = match[0];
-      value = match[1];
+      operation = match[1];
+      value = Number(match[2]);
     }
 
     return isNaN(value) ? { value: 0, operation: '' } : { value, operation };

--- a/template-base-3/template/src/utils/formatter.js
+++ b/template-base-3/template/src/utils/formatter.js
@@ -62,8 +62,8 @@ const parseLogicalOperation = (value) => {
 
     let operation;
     if (match) {
-      operation = match[0];
-      value = match[1];
+      operation = match[1];
+      value = Number(match[2]);
     }
 
     return isNaN(value) ? { value: 0, operation: '' } : { value, operation };


### PR DESCRIPTION
Use proper `parseLogicalOperation` from `sample-app-3`.

Fixes
 * https://app.shortcut.com/cartoteam/story/211256/template-base-2-the-x-axis-labels-has-a-wrong-value-in-the-histogram-widget
 * https://app.shortcut.com/cartoteam/story/210538/template-base-3-the-x-axis-labels-has-a-wrong-value-in-the-histogram-widget