### PR TITLE
react-map-gl 7

### DIFF
--- a/template-sample-app-3/template/config-overrides.js
+++ b/template-sample-app-3/template/config-overrides.js
@@ -1,11 +1,11 @@
 /* config-overrides.js */
+
+const { override, babelInclude, addWebpackAlias } = require('customize-cra');
 const path = require('path');
 
-module.exports = function override(config, env) {
-  const newConfig = config;
-
-  newConfig.resolve.alias = {
-    ...newConfig.resolve.alias,
+module.exports = override(
+  babelInclude([path.resolve('src'), path.resolve('./node_modules/react-map-gl')]),
+  addWebpackAlias({
     react: path.resolve('./node_modules/react'),
     'react-redux': path.resolve('./node_modules/react-redux'),
     '@material-ui/core': path.resolve('./node_modules/@material-ui/core'),
@@ -14,7 +14,5 @@ module.exports = function override(config, env) {
     '@deck.gl/extensions': path.resolve('./node_modules/@deck.gl/extensions'),
     '@nebula.gl/edit-modes': path.resolve('./node_modules/@nebula.gl/edit-modes'),
     '@nebula.gl/layers': path.resolve('./node_modules/@nebula.gl/layers'),
-  };
-
-  return newConfig;
-};
+  })
+);

--- a/template-sample-app-3/template/config-overrides.js
+++ b/template-sample-app-3/template/config-overrides.js
@@ -14,7 +14,5 @@ module.exports = override(
     '@deck.gl/extensions': path.resolve('./node_modules/@deck.gl/extensions'),
     '@nebula.gl/edit-modes': path.resolve('./node_modules/@nebula.gl/edit-modes'),
     '@nebula.gl/layers': path.resolve('./node_modules/@nebula.gl/layers'),
-    // so that react-map-gl doesn't complain about not finding mapbox-gl
-    'mapbox-gl': path.resolve('./node_modules/maplibre-gl'),
   })
 );

--- a/template-sample-app-3/template/config-overrides.js
+++ b/template-sample-app-3/template/config-overrides.js
@@ -14,5 +14,7 @@ module.exports = override(
     '@deck.gl/extensions': path.resolve('./node_modules/@deck.gl/extensions'),
     '@nebula.gl/edit-modes': path.resolve('./node_modules/@nebula.gl/edit-modes'),
     '@nebula.gl/layers': path.resolve('./node_modules/@nebula.gl/layers'),
+    // so that react-map-gl doesn't complain about not finding mapbox-gl
+    'mapbox-gl': path.resolve('./node_modules/maplibre-gl'),
   })
 );

--- a/template-sample-app-3/template/package.dev.json
+++ b/template-sample-app-3/template/package.dev.json
@@ -38,7 +38,7 @@
     "react": "^17.0.2",
     "react-app-polyfill": "^2.0.0",
     "react-dom": "^17.0.2",
-    "react-map-gl": "^5.3.17",
+    "react-map-gl": "^7.0.10",
     "react-redux": "^7.2.5",
     "react-router-dom": "^6.0.0-beta.4",
     "react-scripts": "4.0.3"
@@ -71,14 +71,24 @@
     "updateSupportedBrowsers": "echo \"var browserRegex = $(npx browserslist-useragent-regexp --allowHigherVersions);\" > public/supportedBrowsers.js"
   },
   "eslintConfig": {
-    "extends": ["react-app", "prettier"],
-    "plugins": ["prettier"],
+    "extends": [
+      "react-app",
+      "prettier"
+    ],
+    "plugins": [
+      "prettier"
+    ],
     "rules": {
       "prettier/prettier": "warn"
     }
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all", "not explorer 11"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all",
+      "not explorer 11"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
@@ -91,7 +101,13 @@
     }
   },
   "lint-staged": {
-    "*.+(js|jsx)": ["yarn lint:fix", "git add"],
-    "*.+(js|jsx|json|css|md)": ["prettier --write", "git add"]
+    "*.+(js|jsx)": [
+      "yarn lint:fix",
+      "git add"
+    ],
+    "*.+(js|jsx|json|css|md)": [
+      "prettier --write",
+      "git add"
+    ]
   }
 }

--- a/template-sample-app-3/template/package.dev.json
+++ b/template-sample-app-3/template/package.dev.json
@@ -35,6 +35,7 @@
     "echarts": "^5.2.0",
     "echarts-for-react": "^3.0.1",
     "history": "^5.0.1",
+    "mapbox-gl": "1",
     "react": "^17.0.2",
     "react-app-polyfill": "^2.0.0",
     "react-dom": "^17.0.2",
@@ -44,6 +45,7 @@
     "react-scripts": "4.0.3"
   },
   "devDependencies": {
+    "customize-cra": "^1.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.1",
     "firebase-tools": "^9.18.0",

--- a/template-sample-app-3/template/package.dev.json
+++ b/template-sample-app-3/template/package.dev.json
@@ -35,7 +35,7 @@
     "echarts": "^5.2.0",
     "echarts-for-react": "^3.0.1",
     "history": "^5.0.1",
-    "mapbox-gl": "1",
+    "maplibre-gl": "^2.1.7",
     "react": "^17.0.2",
     "react-app-polyfill": "^2.0.0",
     "react-dom": "^17.0.2",

--- a/template-sample-app-3/template/package.dev.json
+++ b/template-sample-app-3/template/package.dev.json
@@ -35,6 +35,7 @@
     "echarts": "^5.2.0",
     "echarts-for-react": "^3.0.1",
     "history": "^5.0.1",
+    "mapbox-gl": "npm:empty-npm-package@1.0.0",
     "maplibre-gl": "^2.1.7",
     "react": "^17.0.2",
     "react-app-polyfill": "^2.0.0",

--- a/template-sample-app-3/template/src/components/common/map/DeckGLComponent.js
+++ b/template-sample-app-3/template/src/components/common/map/DeckGLComponent.js
@@ -35,7 +35,7 @@ export default function DeckGLComponent({ layers }) {
         mapLib={maplibregl}
         reuseMaps
         mapStyle={basemap.options.mapStyle}
-        preventStyleDiffing
+        styleDiffing={false}
       />
     </DeckGL>
   );

--- a/template-sample-app-3/template/src/components/common/map/DeckGLComponent.js
+++ b/template-sample-app-3/template/src/components/common/map/DeckGLComponent.js
@@ -1,6 +1,7 @@
 import DeckGL from '@deck.gl/react';
 import { useSelector } from 'react-redux';
-import { Map } from 'react-map-gl';
+import Map from 'react-map-gl';
+import maplibregl from 'maplibre-gl';
 import { useTheme, useMediaQuery } from '@material-ui/core';
 import { BASEMAPS } from '@carto/react-basemaps';
 import { useMapHooks } from './useMapHooks';
@@ -30,7 +31,12 @@ export default function DeckGLComponent({ layers }) {
       getTooltip={handleTooltip}
       pickingRadius={isMobile ? 10 : 0}
     >
-      <Map reuseMaps mapStyle={basemap.options.mapStyle} preventStyleDiffing />
+      <Map
+        mapLib={maplibregl}
+        reuseMaps
+        mapStyle={basemap.options.mapStyle}
+        preventStyleDiffing
+      />
     </DeckGL>
   );
 }

--- a/template-sample-app-3/template/src/components/common/map/DeckGLComponent.js
+++ b/template-sample-app-3/template/src/components/common/map/DeckGLComponent.js
@@ -1,6 +1,6 @@
 import DeckGL from '@deck.gl/react';
 import { useSelector } from 'react-redux';
-import { StaticMap } from 'react-map-gl';
+import { Map } from 'react-map-gl';
 import { useTheme, useMediaQuery } from '@material-ui/core';
 import { BASEMAPS } from '@carto/react-basemaps';
 import { useMapHooks } from './useMapHooks';
@@ -30,7 +30,7 @@ export default function DeckGLComponent({ layers }) {
       getTooltip={handleTooltip}
       pickingRadius={isMobile ? 10 : 0}
     >
-      <StaticMap reuseMaps mapStyle={basemap.options.mapStyle} preventStyleDiffing />
+      <Map reuseMaps mapStyle={basemap.options.mapStyle} preventStyleDiffing />
     </DeckGL>
   );
 }

--- a/template-sample-app-3/template/src/components/common/map/GoogleMapsComponent.js
+++ b/template-sample-app-3/template/src/components/common/map/GoogleMapsComponent.js
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import 'mapbox-gl/dist/mapbox-gl.css';
+import 'maplibre-gl/dist/maplibre-gl.css';
 import { BASEMAPS, GoogleMap } from '@carto/react-basemaps';
 import { useMapHooks } from './useMapHooks';
 

--- a/template-sample-app-3/template/src/components/common/map/Map.js
+++ b/template-sample-app-3/template/src/components/common/map/Map.js
@@ -1,6 +1,6 @@
 import { lazy } from 'react';
 import { useSelector } from 'react-redux';
-import 'mapbox-gl/dist/mapbox-gl.css';
+import 'maplibre-gl/dist/maplibre-gl.css';
 import { makeStyles } from '@material-ui/core';
 import { BASEMAPS } from '@carto/react-basemaps';
 


### PR DESCRIPTION
Update `react-map-gl` to version 7 and use `maplibre-gl` instead of `mapbox-gl`.

**For now just in `template-sample-app-3` as PoC.**

Everything seems to work fine, including feature selection.

![Capture d’écran de 2022-03-29 12-15-43](https://user-images.githubusercontent.com/243653/160592059-67820eae-001e-4f38-8c85-a3b473b026f2.png)


Necessary changes:
- code
  - `StaticMap` doesn't exist anymore in `react-map-gl`, there is only a generic `Map` component
  - A `mapLib` prop must be passed to this component to explicitly choose MapLibre-GL in place of MapBox-GL
  - Inclusion of Mapbox-GL CSS has to be replaced with the one from MapLibre-GL
- config
  - `react-map-gl@7` is published as ESM and can't be built directly, it needs to be passed through Babel. So I changed the CRA override to add it and installed `customize-cra` to help with this change.
  - inclusion of `maplibre-gl` as a dependency
  - I didn't understand why, but this [conditional import of MapBox-GL in react-map-gl](https://github.com/visgl/react-map-gl/blob/master/src/components/map.tsx#L81) doesn't work as expected. Even with the `mapLib` prop correctly passed, the component still tries to import the real `mapbox-gl` during the build phase. Maybe smth strange in the way webpack resolves async imports?
The doc actually [proposes to use a dummy package in place of mapbox-gl](http://visgl.github.io/react-map-gl/docs/get-started/get-started#using-with-a-mapbox-gl-fork) (thanks Borja for pointing me to it)