### PR TITLE
Prepare template-sample-app-3 for 1.3.0

### DIFF
--- a/template-sample-app-3/template/src/components/views/Stores.js
+++ b/template-sample-app-3/template/src/components/views/Stores.js
@@ -5,6 +5,7 @@ import {
   HistogramWidget,
   ScatterPlotWidget,
   TableWidget,
+  BarWidget,
 } from '@carto/react-widgets';
 import { currencyFormatter, intervalsFormatter } from 'utils/formatter';
 
@@ -91,8 +92,21 @@ export default function Stores() {
         <Divider />
 
         <FormulaWidget
-          id='totalRevenue'
-          title='Total revenue'
+          id='totalRevenueGlobal'
+          title='Total revenue (Global)'
+          dataSource={storesSource.id}
+          column='revenue'
+          operation={AggregationTypes.SUM}
+          formatter={currencyFormatter}
+          onError={onTotalRevenueWidgetError}
+          global={true}
+        />
+
+        <Divider />
+
+        <FormulaWidget
+          id='totalRevenueViewport'
+          title='Total revenue (Viewport)'
           dataSource={storesSource.id}
           column='revenue'
           operation={AggregationTypes.SUM}
@@ -102,11 +116,24 @@ export default function Stores() {
 
         <Divider />
 
-        <CategoryWidget
+        <BarWidget
           id='revenueByStoreType'
           title='Revenue by store type'
           dataSource={storesSource.id}
           column='storetype'
+          operationColumn='revenue'
+          operation={AggregationTypes.SUM}
+          yAxisFormatter={currencyFormatter}
+          onError={onRevenuePerTypeWidgetError}
+        />
+
+        <Divider />
+
+        <CategoryWidget
+          id='revenueByState'
+          title='Revenue by state'
+          dataSource={storesSource.id}
+          column='state'
           operationColumn='revenue'
           operation={AggregationTypes.SUM}
           formatter={currencyFormatter}
@@ -121,7 +148,6 @@ export default function Stores() {
           dataSource={storesSource.id}
           column='revenue'
           operation={AggregationTypes.COUNT}
-          ticks={[1200000, 1300000, 1400000, 1500000, 1600000, 1700000, 1800000]}
           formatter={intervalsFormatter}
           xAxisFormatter={currencyFormatter}
           onError={onStoresByRevenueWidgetError}

--- a/template-sample-app-3/template/src/components/views/Tileset.js
+++ b/template-sample-app-3/template/src/components/views/Tileset.js
@@ -95,7 +95,7 @@ export default function Tileset() {
         formatter={intervalsFormatter}
         operation={AggregationTypes.COUNT}
         column='aggregated_total'
-        ticks={[10, 100, 1e3, 1e4, 1e5, 1e6]}
+        // ticks={[10, 100, 1e3, 1e4, 1e5, 1e6]}
         onError={onHistogramCountWidgetError}
       />
 

--- a/template-sample-app-3/template/src/components/views/Tileset.js
+++ b/template-sample-app-3/template/src/components/views/Tileset.js
@@ -95,7 +95,6 @@ export default function Tileset() {
         formatter={intervalsFormatter}
         operation={AggregationTypes.COUNT}
         column='aggregated_total'
-        // ticks={[10, 100, 1e3, 1e4, 1e5, 1e6]}
         onError={onHistogramCountWidgetError}
       />
 


### PR DESCRIPTION
Stores view:

![image](https://user-images.githubusercontent.com/9151432/175898207-0aa7f33c-96fd-4789-956e-e3e39afa429a.png)

Changes:
- Remove ticks in HistogramWidget
- Use BarWidget for storetype
- Add CategoryWidget for states
- Add global formula widget with the sum of revenues to compare with the viewport one

Tileset view:

![Screenshot 2022-06-27 at 10 43 07](https://user-images.githubusercontent.com/9151432/175898282-5db28c4e-ce0d-440a-98f4-fa22e6d79c8a.png)

Changes:
- Remove ticks in HistogramWidget.