### PR TITLE
Do not add the organization property if it is empty

### DIFF
--- a/template-base-3-typescript/template/src/index.tsx
+++ b/template-base-3-typescript/template/src/index.tsx
@@ -49,7 +49,7 @@ function OauthProvider({ children }: { children: JSX.Element }) {
     <Auth0Provider
       domain={domain}
       clientId={clientId}
-      organization={organizationId}
+      {...( organizationId !== '' ? { organization: organizationId } : {} )}
       redirectUri={window.location.origin}
       scopes={scopes.join(' ')}
       audience={audience}

--- a/template-base-3/template/src/index.js
+++ b/template-base-3/template/src/index.js
@@ -46,7 +46,7 @@ function OauthProvider({ children }) {
     <Auth0Provider
       domain={domain}
       clientId={clientId}
-      organization={organizationId}
+      {...( organizationId !== '' ? { organization: organizationId } : {} )}
       redirectUri={window.location.origin}
       scopes={scopes.join(' ')}
       audience={audience}

--- a/template-sample-app-3/template/src/index.js
+++ b/template-sample-app-3/template/src/index.js
@@ -46,7 +46,7 @@ function OauthProvider({ children }) {
     <Auth0Provider
       domain={domain}
       clientId={clientId}
-      organization={organizationId}
+      {...( organizationId !== '' ? { organization: organizationId } : {} )}
       redirectUri={window.location.origin}
       scopes={scopes.join(' ')}
       audience={audience}


### PR DESCRIPTION
If we add the organization parameter to the Auth0Provider component and it is empty, authentication is not going to work because there is no organization ID matching the empty string.

This fix only adds the organization parameter if the corresponding property in the initialStateSlice is not an empty string.