### PR TITLE
Use the GeoJsonLayer instead of the CartoLayer in sample-app-3 template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Not released
 
+- Do not add the organization property if it is empty [#345](https://github.com/CartoDB/carto-react-template/pull/345)
+- Use the GeoJsonLayer instead of the CartoLayer in sample-app-3 template [#346](https://github.com/CartoDB/carto-react-template/pull/346)
+
 ## 1.3
 
 ### 1.3.0-beta.1 (2022-07-06)


### PR DESCRIPTION
The CartoLayer only works with dynamic tiles so feature dropping can happen at lower zoom levels. If feature dropping happens, the widgets linked to the same source are not going to work. If we want the widgets to work at all zoom levels, we need to fetch the data in GeoJSON format and then use the GeoJsonLayer intead of the CartoLayer.
