### PR TITLE
Prerelease 1.3.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Not released
 
+## 1.3
+
+### 1.3.0-beta.2 (2022-07-07)
+
 - Do not add the organization property if it is empty [#345](https://github.com/CartoDB/carto-react-template/pull/345)
 - Use the GeoJsonLayer instead of the CartoLayer in sample-app-3 template [#346](https://github.com/CartoDB/carto-react-template/pull/346)
-
-## 1.3
 
 ### 1.3.0-beta.1 (2022-07-06)
 

--- a/template-base-2/package.json
+++ b/template-base-2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-base-2",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-base-2/template/package.dev.json
+++ b/template-base-2/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "private": true,
   "dependencies": {
     "@carto/react-api": "^1.3.0-beta.6",

--- a/template-base-3-typescript/package.json
+++ b/template-base-3-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-base-3-typescript",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-base-3-typescript/template/package.dev.json
+++ b/template-base-3-typescript/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "private": true,
   "dependencies": {
     "@auth0/auth0-react": "^1.7.0",

--- a/template-base-3/package.json
+++ b/template-base-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-base-3",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-base-3/template/package.dev.json
+++ b/template-base-3/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "private": true,
   "dependencies": {
     "@auth0/auth0-react": "^1.7.0",

--- a/template-sample-app-2/package.json
+++ b/template-sample-app-2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-sample-app-2",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-sample-app-2/template/package.dev.json
+++ b/template-sample-app-2/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "private": true,
   "dependencies": {
     "@carto/react-api": "^1.3.0-beta.6",

--- a/template-sample-app-3/package.json
+++ b/template-sample-app-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-sample-app-3",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-sample-app-3/template/package.dev.json
+++ b/template-sample-app-3/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "private": true,
   "dependencies": {
     "@auth0/auth0-react": "^1.7.0",


### PR DESCRIPTION
- Do not add the organization property if it is empty [#345](https://github.com/CartoDB/carto-react-template/pull/345)

- Use the GeoJsonLayer instead of the CartoLayer in sample-app-3 template [#346](https://github.com/CartoDB/carto-react-template/pull/346)