### PR TITLE
Update to 2.2 (published)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+## 2.2 (2023-08-01)
+
 - Support for signup new users. With this feature, new users are returned back to the application after the signup. For SSO organizations it will be transparent and new users will be automatically registered in CARTO. Users must sign up in the same organization where the SPA Application was created. [#366](https://github.com/CartoDB/carto-react-template/pull/366)
 
 ## 2.1

--- a/template-base-3-typescript/package.json
+++ b/template-base-3-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-base-3-typescript",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-base-3-typescript/template/package.dev.json
+++ b/template-base-3-typescript/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "private": true,
   "dependencies": {
     "@auth0/auth0-react": "^1.7.0",

--- a/template-base-3/package.json
+++ b/template-base-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-base-3",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-base-3/template/package.dev.json
+++ b/template-base-3/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "private": true,
   "dependencies": {
     "@auth0/auth0-react": "^1.7.0",

--- a/template-sample-app-3/package.json
+++ b/template-sample-app-3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cra-template-sample-app-3",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "keywords": [
     "react",
     "create-react-app",

--- a/template-sample-app-3/template/package.dev.json
+++ b/template-sample-app-3/template/package.dev.json
@@ -1,6 +1,6 @@
 {
   "name": "carto-for-react",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "private": true,
   "dependencies": {
     "@auth0/auth0-react": "^1.7.0",


### PR DESCRIPTION
Register proper 2.2.0 for tagging purposes