### PR TITLE
Minor JIT provisioning improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Not released
 
-- Minor improvements for the flow to signup new users []()
+- Minor JIT provisioning flow improvements [#369](https://github.com/CartoDB/carto-react-template/pull/369)
 
 ## 2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Not released
 
+- Minor improvements for the flow to signup new users []()
+
 ## 2.3
 
 ## 2.3.0 (2023-11-30)

--- a/template-base-3-typescript/template/src/hooks/Auth0.ts
+++ b/template-base-3-typescript/template/src/hooks/Auth0.ts
@@ -14,7 +14,6 @@ export default function useAuth() {
 
   const accountsUrl = initialState.accountsUrl;
   const organizationId = initialState.oauth?.organizationId;
-  const namespace = initialState.oauth?.namespace;
 
   const hasForceLogin = searchParams.has(FORCE_LOGIN_PARAM);
 
@@ -25,8 +24,9 @@ export default function useAuth() {
 
   const userMetadata = useMemo(() => {
     if (!user) return;
-    return user[`${namespace}user_metadata`];
-  }, [user, namespace]);
+    const userMetadataKey = Object.keys(user).find((key)  => /.*?user_metadata$/.test(key));
+    return userMetadataKey && user[userMetadataKey];
+  }, [user]);
 
   const redirectAccountUri = useMemo(() => {
     return `${accountsUrl}${organizationId ? `sso/${organizationId}` : ''}`;

--- a/template-base-3-typescript/template/src/hooks/Auth0.ts
+++ b/template-base-3-typescript/template/src/hooks/Auth0.ts
@@ -24,8 +24,7 @@ export default function useAuth() {
 
   const userMetadata = useMemo(() => {
     if (!user) return;
-    const userMetadataKey = Object.keys(user).find((key)  => /.*?user_metadata$/.test(key));
-    return userMetadataKey && user[userMetadataKey];
+    return user['http://app.carto.com/user_metadata'];
   }, [user]);
 
   const redirectAccountUri = useMemo(() => {

--- a/template-base-3-typescript/template/src/store/initialStateSlice.ts
+++ b/template-base-3-typescript/template/src/store/initialStateSlice.ts
@@ -24,7 +24,6 @@ export const initialState: InitialCarto3State = {
     domain: 'auth.carto.com',
     clientId: '', // type here your application clientId
     organizationId: '', // organizationId is required for SSO
-    namespace: 'http://app.carto.com/',
     scopes: [
       'read:current_user',
       'update:current_user',

--- a/template-base-3-typescript/template/src/store/initialStateSlice.ts
+++ b/template-base-3-typescript/template/src/store/initialStateSlice.ts
@@ -19,7 +19,7 @@ export const initialState: InitialCarto3State = {
   },
   googleApiKey: '', // only required when using a Google Basemap,
   googleMapId: '', // only required when using a Google Custom Basemap
-  accountsUrl: 'http://app.carto.com/',
+  accountsUrl: 'https://app.carto.com/',
   oauth: {
     domain: 'auth.carto.com',
     clientId: '', // type here your application clientId

--- a/template-base-3/template/src/hooks/Auth0.js
+++ b/template-base-3/template/src/hooks/Auth0.js
@@ -14,7 +14,6 @@ export default function useAuth() {
 
   const accountsUrl = initialState.accountsUrl;
   const organizationId = initialState.oauth?.organizationId;
-  const namespace = initialState.oauth?.namespace;
 
   const hasForceLogin = searchParams.has(FORCE_LOGIN_PARAM);
 
@@ -25,8 +24,9 @@ export default function useAuth() {
 
   const userMetadata = useMemo(() => {
     if (!user) return;
-    return user[`${namespace}user_metadata`];
-  }, [user, namespace]);
+    const userMetadataKey = Object.keys(user).find((key)  => /.*?user_metadata$/.test(key));
+    return userMetadataKey && user[userMetadataKey];
+  }, [user]);
 
   const redirectAccountUri = useMemo(() => {
     return `${accountsUrl}${organizationId ? `sso/${organizationId}` : ''}`;

--- a/template-base-3/template/src/hooks/Auth0.js
+++ b/template-base-3/template/src/hooks/Auth0.js
@@ -24,8 +24,7 @@ export default function useAuth() {
 
   const userMetadata = useMemo(() => {
     if (!user) return;
-    const userMetadataKey = Object.keys(user).find((key)  => /.*?user_metadata$/.test(key));
-    return userMetadataKey && user[userMetadataKey];
+    return user['http://app.carto.com/user_metadata'];
   }, [user]);
 
   const redirectAccountUri = useMemo(() => {

--- a/template-base-3/template/src/store/initialStateSlice.js
+++ b/template-base-3/template/src/store/initialStateSlice.js
@@ -19,7 +19,6 @@ export const initialState = {
   googleMapId: '', // only required when using a Google Custom Basemap
   accountsUrl: 'https://app.carto.com/',
   oauth: {
-    namespace: 'http://app.carto.com/',
     domain: 'auth.carto.com',
     clientId: '', // type here your application clientId
     organizationId: '', // organizationId is required for SSO

--- a/template-base-3/template/src/store/initialStateSlice.js
+++ b/template-base-3/template/src/store/initialStateSlice.js
@@ -17,7 +17,7 @@ export const initialState = {
   },
   googleApiKey: '', // only required when using a Google Basemap
   googleMapId: '', // only required when using a Google Custom Basemap
-  accountsUrl: 'http://app.carto.com/',
+  accountsUrl: 'https://app.carto.com/',
   oauth: {
     namespace: 'http://app.carto.com/',
     domain: 'auth.carto.com',

--- a/template-sample-app-3/template/src/hooks/Auth0.js
+++ b/template-sample-app-3/template/src/hooks/Auth0.js
@@ -14,7 +14,6 @@ export default function useAuth() {
 
   const accountsUrl = initialState.accountsUrl;
   const organizationId = initialState.oauth?.organizationId;
-  const namespace = initialState.oauth?.namespace;
 
   const hasForceLogin = searchParams.has(FORCE_LOGIN_PARAM);
 
@@ -25,8 +24,9 @@ export default function useAuth() {
 
   const userMetadata = useMemo(() => {
     if (!user) return;
-    return user[`${namespace}user_metadata`];
-  }, [user, namespace]);
+    const userMetadataKey = Object.keys(user).find((key)  => /.*?user_metadata$/.test(key));
+    return userMetadataKey && user[userMetadataKey];
+  }, [user]);
 
   const redirectAccountUri = useMemo(() => {
     return `${accountsUrl}${organizationId ? `sso/${organizationId}` : ''}`;

--- a/template-sample-app-3/template/src/hooks/Auth0.js
+++ b/template-sample-app-3/template/src/hooks/Auth0.js
@@ -24,8 +24,7 @@ export default function useAuth() {
 
   const userMetadata = useMemo(() => {
     if (!user) return;
-    const userMetadataKey = Object.keys(user).find((key)  => /.*?user_metadata$/.test(key));
-    return userMetadataKey && user[userMetadataKey];
+    return user['http://app.carto.com/user_metadata'];
   }, [user]);
 
   const redirectAccountUri = useMemo(() => {


### PR DESCRIPTION
## Changes

- Use `https` for `accountsUrl`, to support JIT provisioning flow inside iframes.
- Remove `namespace` JIT provisioning parameter that is not actually configurable.